### PR TITLE
using lumberjack logger for file logging (with rotation)

### DIFF
--- a/cmd/bspagent/main.go
+++ b/cmd/bspagent/main.go
@@ -22,6 +22,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/ubiq/go-ubiq/rlp"
 	"gopkg.in/avro.v0"
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/covalenthq/bsp-agent/internal/config"
 	"github.com/covalenthq/bsp-agent/internal/event"
@@ -65,7 +66,14 @@ func init() {
 	}}
 	formatter.Line = true
 	log.SetFormatter(&formatter)
-	log.SetOutput(os.Stdout)
+	bspLoggerOutput := utils.NewLoggerOut(os.Stdout, &lumberjack.Logger{
+		// logs folder created/searched in directory in which agent was started.
+		Filename:   "./logs/log.log",
+		MaxSize:    100, // megabytes
+		MaxBackups: 7,
+		MaxAge:     10, // days
+	})
+	log.SetOutput(&bspLoggerOutput)
 	log.SetLevel(log.InfoLevel)
 	log.WithFields(log.Fields{"file": "main.go"}).Info("bsp-agent is running...")
 }

--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,6 @@ require (
 	github.com/ubiq/go-ubiq v3.0.1+incompatible
 	google.golang.org/api v0.70.0
 	gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -979,6 +979,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20200619000410-60c24ae608a6/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=

--- a/internal/utils/bsploggerout.go
+++ b/internal/utils/bsploggerout.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+)
+
+// BsploggerOutput logger that can log to file (lumberjack) as well as stdout
+type BsploggerOutput struct {
+	writers []io.Writer
+}
+
+// NewLoggerOut combine all writers to create a new writer
+func NewLoggerOut(writers ...io.Writer) BsploggerOutput {
+	return BsploggerOutput{writers: writers}
+}
+
+func (logger *BsploggerOutput) Write(p []byte) (n int, err error) {
+	var lastn int
+	var lasterr error
+	for _, writer := range logger.writers {
+		lastn, lasterr = writer.Write(p)
+	}
+
+	if lasterr != nil {
+		return lastn, fmt.Errorf("error from last log writer: %w", lasterr)
+	}
+
+	return lastn, nil
+}


### PR DESCRIPTION
bsp-agent logging now writes to both file and stdout. File rotates everyday and is kept for the last 7 days.