### PR TITLE
update pre-commit linter hook to run on entire repo

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,13 +15,10 @@ fi
 
 PASS=true
 
-for FILE in $STAGED_GO_FILES
-do
-  golangci-lint run $FILE
-  if [[ $? == 1 ]]; then
+golangci-lint run
+if [[ $? == 1 ]]; then
     PASS=false
-  fi
-done
+fi
 
 if ! $PASS; then
   printf "COMMIT FAILED\n"


### PR DESCRIPTION
running on each file isn't as comprehensive as running against the entire repo. See this [issue](https://github.com/golangci/golangci-lint/issues/1574)