### PR TITLE
Deploy for CQT testnet with adapted Proofchain

### DIFF
--- a/cmd/bspagent/main.go
+++ b/cmd/bspagent/main.go
@@ -276,7 +276,7 @@ func processStream(config *config.Config, replicaCodec *goavro.Codec, redisClien
 	newEvent, _ := event.NewBlockReplicaEvent()
 	replica, err := handler.ParseStreamToEvent(newEvent, hash, &blockReplica)
 	objectType := blockReplica.Type[5:]
-	objectHash := blockReplica.Hash
+	objectReplica := &blockReplica
 	if err != nil {
 		log.Error("error on process event: ", err)
 	} else {
@@ -291,7 +291,7 @@ func processStream(config *config.Config, replicaCodec *goavro.Codec, redisClien
 			replicationSegment.Elements = uint64(segmentLengthFlag)
 			replicaSegmentName = fmt.Sprint(replica.Data.NetworkId) + "-" + fmt.Sprint(replicationSegment.StartBlock) + objectType
 			// avro encode, prove and upload
-			_, err := handler.EncodeProveAndUploadReplicaSegment(ctx, &config.EthConfig, replicaCodec, &replicationSegment, objectHash, storageClient, ethClient, binaryFilePathFlag, replicaBucketFlag, replicaSegmentName, proofChainFlag)
+			_, err := handler.EncodeProveAndUploadReplicaSegment(ctx, &config.EthConfig, replicaCodec, &replicationSegment, objectReplica, storageClient, ethClient, binaryFilePathFlag, replicaBucketFlag, replicaSegmentName, proofChainFlag)
 			if err != nil {
 				log.Error("failed to avro encode, prove and upload block-result segment with err: ", err)
 			}

--- a/cmd/bspagent/main.go
+++ b/cmd/bspagent/main.go
@@ -289,7 +289,7 @@ func processStream(config *config.Config, replicaCodec *goavro.Codec, redisClien
 		if len(replicationSegment.BlockReplicaEvent) == segmentLengthFlag {
 			replicationSegment.EndBlock = replica.Data.Header.Number.Uint64()
 			replicationSegment.Elements = uint64(segmentLengthFlag)
-			replicaSegmentName = fmt.Sprint(replica.Data.NetworkId) + "-" + fmt.Sprint(replicationSegment.StartBlock) + "-" + fmt.Sprint(replicationSegment.EndBlock) + objectType + "-" + "segment"
+			replicaSegmentName = fmt.Sprint(replica.Data.NetworkId) + "-" + fmt.Sprint(replicationSegment.StartBlock) + objectType
 			// avro encode, prove and upload
 			_, err := handler.EncodeProveAndUploadReplicaSegment(ctx, &config.EthConfig, replicaCodec, &replicationSegment, objectHash, storageClient, ethClient, binaryFilePathFlag, replicaBucketFlag, replicaSegmentName, proofChainFlag)
 			if err != nil {

--- a/cmd/bspagent/main.go
+++ b/cmd/bspagent/main.go
@@ -276,6 +276,7 @@ func processStream(config *config.Config, replicaCodec *goavro.Codec, redisClien
 	newEvent, _ := event.NewBlockReplicaEvent()
 	replica, err := handler.ParseStreamToEvent(newEvent, hash, &blockReplica)
 	objectType := blockReplica.Type[5:]
+	objectHash := blockReplica.Hash
 	if err != nil {
 		log.Error("error on process event: ", err)
 	} else {
@@ -290,7 +291,7 @@ func processStream(config *config.Config, replicaCodec *goavro.Codec, redisClien
 			replicationSegment.Elements = uint64(segmentLengthFlag)
 			replicaSegmentName = fmt.Sprint(replica.Data.NetworkId) + "-" + fmt.Sprint(replicationSegment.StartBlock) + "-" + fmt.Sprint(replicationSegment.EndBlock) + objectType + "-" + "segment"
 			// avro encode, prove and upload
-			_, err := handler.EncodeProveAndUploadReplicaSegment(ctx, &config.EthConfig, replicaCodec, &replicationSegment, storageClient, ethClient, binaryFilePathFlag, replicaBucketFlag, replicaSegmentName, proofChainFlag)
+			_, err := handler.EncodeProveAndUploadReplicaSegment(ctx, &config.EthConfig, replicaCodec, &replicationSegment, objectHash, storageClient, ethClient, binaryFilePathFlag, replicaBucketFlag, replicaSegmentName, proofChainFlag)
 			if err != nil {
 				log.Error("failed to avro encode, prove and upload block-result segment with err: ", err)
 			}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/linkedin/goavro/v2"
 	log "github.com/sirupsen/logrus"
-	"github.com/ubiq/go-ubiq/common"
 
 	"github.com/covalenthq/bsp-agent/internal/config"
 	"github.com/covalenthq/bsp-agent/internal/event"
@@ -49,7 +48,7 @@ func ParseStreamToEvent(e event.Event, hash string, data *types.BlockReplica) (*
 }
 
 // EncodeProveAndUploadReplicaSegment atomically encodes the event into an AVRO binary, proves the replica on proof-chain and upload and stores the binary file
-func EncodeProveAndUploadReplicaSegment(ctx context.Context, config *config.EthConfig, replicaAvro *goavro.Codec, replicaSegment *event.ReplicationSegment, blockHash common.Hash, storageClient *storage.Client, ethClient *ethclient.Client, binaryLocalPath, replicaBucket, segmentName, proofChain string) (string, error) {
+func EncodeProveAndUploadReplicaSegment(ctx context.Context, config *config.EthConfig, replicaAvro *goavro.Codec, replicaSegment *event.ReplicationSegment, blockReplica *types.BlockReplica, storageClient *storage.Client, ethClient *ethclient.Client, binaryLocalPath, replicaBucket, segmentName, proofChain string) (string, error) {
 	var replicaURL string
 	replicaSegmentAvro, err := EncodeReplicaSegmentToAvro(replicaAvro, replicaSegment)
 	if err != nil {
@@ -66,7 +65,7 @@ func EncodeProveAndUploadReplicaSegment(ctx context.Context, config *config.EthC
 		replicaURL = "only local ./bin/"
 	}
 
-	go proof.SendBlockReplicaProofTx(ctx, config, proofChain, ethClient, replicaSegment.EndBlock, replicaSegment.Elements, replicaSegmentAvro, replicaURL, blockHash, proofTxHash)
+	go proof.SendBlockReplicaProofTx(ctx, config, proofChain, ethClient, replicaSegment.EndBlock, replicaSegment.Elements, replicaSegmentAvro, replicaURL, blockReplica, proofTxHash)
 	pTxHash := <-proofTxHash
 	if pTxHash != "" {
 		log.Info("Proof-chain tx hash: ", pTxHash, " for block-replica segment: ", segmentName)

--- a/internal/proof/proof.go
+++ b/internal/proof/proof.go
@@ -32,6 +32,7 @@ func SendBlockReplicaProofTx(ctx context.Context, config *config.EthConfig, proo
 
 		return
 	}
+
 	contractAddress := common.HexToAddress(proofChain)
 	contract, err := NewProofChain(contractAddress, ethClient)
 	if err != nil {
@@ -47,8 +48,6 @@ func SendBlockReplicaProofTx(ctx context.Context, config *config.EthConfig, proo
 		return
 	}
 	sha256Result := sha256.Sum256(jsonResult)
-
-	// transaction, err := contract.SubmitBlockSpecimenProof(opts, chainID, chainHeight, uint64(len(jsonResult)), chainLen, sha256Result, replicaURL)
 
 	transaction, err := contract.SubmitBlockSpecimenProof(opts, chainID, chainHeight, blockHash, sha256Result, replicaURL)
 

--- a/internal/proof/proof.go
+++ b/internal/proof/proof.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/covalenthq/bsp-agent/internal/config"
+	ty "github.com/covalenthq/bsp-agent/internal/types"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	log "github.com/sirupsen/logrus"
-	ubiq "github.com/ubiq/go-ubiq/common"
 )
 
 var (
@@ -22,11 +22,11 @@ var (
 )
 
 // SendBlockReplicaProofTx calls the proof-chain contract to make a transaction for the block-replica that it is processing
-func SendBlockReplicaProofTx(ctx context.Context, config *config.EthConfig, proofChain string, ethClient *ethclient.Client, chainHeight uint64, chainLen uint64, resultSegment []byte, replicaURL string, blockHash ubiq.Hash, txHash chan string) {
+func SendBlockReplicaProofTx(ctx context.Context, config *config.EthConfig, proofChain string, ethClient *ethclient.Client, chainHeight uint64, chainLen uint64, resultSegment []byte, replicaURL string, blockReplica *ty.BlockReplica, txHash chan string) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*time.Duration(proofTxTimeout))
 	defer cancel()
 
-	_, opts, chainID, err := getTransactionOpts(ctx, config, ethClient)
+	_, opts, _, err := getTransactionOpts(ctx, config, ethClient)
 	if err != nil {
 		log.Error("error getting transaction ops: ", err.Error())
 
@@ -49,7 +49,7 @@ func SendBlockReplicaProofTx(ctx context.Context, config *config.EthConfig, proo
 	}
 	sha256Result := sha256.Sum256(jsonResult)
 
-	transaction, err := contract.SubmitBlockSpecimenProof(opts, chainID, chainHeight, blockHash, sha256Result, replicaURL)
+	transaction, err := contract.SubmitBlockSpecimenProof(opts, blockReplica.NetworkId, chainHeight, blockReplica.Hash, sha256Result, replicaURL)
 
 	if err != nil {
 		log.Error("error calling deployed contract: ", err)

--- a/internal/proof/proof.go
+++ b/internal/proof/proof.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	log "github.com/sirupsen/logrus"
+	ubiq "github.com/ubiq/go-ubiq/common"
 )
 
 var (
@@ -21,7 +22,7 @@ var (
 )
 
 // SendBlockReplicaProofTx calls the proof-chain contract to make a transaction for the block-replica that it is processing
-func SendBlockReplicaProofTx(ctx context.Context, config *config.EthConfig, proofChain string, ethClient *ethclient.Client, chainHeight uint64, chainLen uint64, resultSegment []byte, replicaURL string, txHash chan string) {
+func SendBlockReplicaProofTx(ctx context.Context, config *config.EthConfig, proofChain string, ethClient *ethclient.Client, chainHeight uint64, chainLen uint64, resultSegment []byte, replicaURL string, blockHash ubiq.Hash, txHash chan string) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*time.Duration(proofTxTimeout))
 	defer cancel()
 
@@ -47,7 +48,9 @@ func SendBlockReplicaProofTx(ctx context.Context, config *config.EthConfig, proo
 	}
 	sha256Result := sha256.Sum256(jsonResult)
 
-	transaction, err := contract.SubmitBlockSpecimenProof(opts, chainID, chainHeight, uint64(len(jsonResult)), chainLen, sha256Result, replicaURL)
+	// transaction, err := contract.SubmitBlockSpecimenProof(opts, chainID, chainHeight, uint64(len(jsonResult)), chainLen, sha256Result, replicaURL)
+
+	transaction, err := contract.SubmitBlockSpecimenProof(opts, chainID, chainHeight, blockHash, sha256Result, replicaURL)
 
 	if err != nil {
 		log.Error("error calling deployed contract: ", err)

--- a/internal/proof/proofchain.abi
+++ b/internal/proof/proofchain.abi
@@ -3,43 +3,32 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "uint64",
         "name": "chainId",
         "type": "uint64"
       },
       {
-        "indexed": true,
-        "internalType": "uint64",
-        "name": "blockHeight",
-        "type": "uint64"
-      },
-      {
         "indexed": false,
         "internalType": "uint64",
-        "name": "specimenSize",
+        "name": "newMaxNumberOfHashesPer24H",
         "type": "uint64"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint64",
-        "name": "specimenLength",
-        "type": "uint64"
-      },
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "specimenHash",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "storageURL",
-        "type": "string"
       }
     ],
-    "name": "BlockSpecimenProductionProofSubmitted",
+    "name": "BlockSpecimenMaxNumberOfHashesPer24HChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newBlockSpecimenMinSubmissionsRequired",
+        "type": "uint128"
+      }
+    ],
+    "name": "BlockSpecimenMinSubmissionRequiredChanged",
     "type": "event"
   },
   {
@@ -58,16 +47,59 @@
         "type": "uint64"
       },
       {
-        "indexed": false,
-        "internalType": "uint128",
-        "name": "reward",
-        "type": "uint128"
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
       },
       {
         "indexed": true,
-        "internalType": "address",
-        "name": "operatorAddress",
-        "type": "address"
+        "internalType": "bytes32",
+        "name": "specimenHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "storageURL",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "submittedStake",
+        "type": "uint128"
+      }
+    ],
+    "name": "BlockSpecimenProductionProofSubmitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "chainId",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "blockHeight",
+        "type": "uint64"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "blockhash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "specimenhash",
+        "type": "bytes32"
       }
     ],
     "name": "BlockSpecimenRewardAwarded",
@@ -103,6 +135,38 @@
       }
     ],
     "name": "BlockSpecimenSessionFinalized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "newStakeRequirement",
+        "type": "uint128"
+      }
+    ],
+    "name": "MinimumRequiredStakeChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "numberOfBlocks",
+        "type": "uint64"
+      }
+    ],
+    "name": "NumberOfBlocksPer24HChanged",
     "type": "event"
   },
   {
@@ -153,6 +217,25 @@
       }
     ],
     "name": "OperatorStoppedRole",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint64",
+        "name": "chainId",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "blockHeight",
+        "type": "uint64"
+      }
+    ],
+    "name": "QuorumNotReached",
     "type": "event"
   },
   {
@@ -249,11 +332,37 @@
       {
         "indexed": false,
         "internalType": "uint64",
+        "name": "minSubmissions",
+        "type": "uint64"
+      }
+    ],
+    "name": "SpecimenSessionMinSubmissionChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
         "name": "newQuorumThreshold",
         "type": "uint64"
       }
     ],
     "name": "SpecimenSessionQuorumChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newInterfaceAddress",
+        "type": "address"
+      }
+    ],
+    "name": "StakingInterfaceChanged",
     "type": "event"
   },
   {
@@ -318,7 +427,7 @@
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "newRole",
+        "name": "newRoleName",
         "type": "bytes32"
       }
     ],
@@ -359,6 +468,11 @@
       },
       {
         "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
         "name": "definitiveSpecimenHash",
         "type": "bytes32"
       }
@@ -370,7 +484,7 @@
   },
   {
     "inputs": [],
-    "name": "blockSpecimenQuorumThresholdNumerator",
+    "name": "blockSpecimenQuorum",
     "outputs": [
       {
         "internalType": "uint64",
@@ -445,6 +559,24 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "chainId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "blockHeight",
+        "type": "uint64"
+      }
+    ],
+    "name": "finalizeAndRewardSpecimenSession",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "getRoleTypes",
     "outputs": [
@@ -461,7 +593,7 @@
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "role",
+        "name": "roleName",
         "type": "bytes32"
       },
       {
@@ -542,6 +674,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "minSubmissionsRequired",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint128",
@@ -558,7 +703,7 @@
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "role",
+        "name": "roleName",
         "type": "bytes32"
       },
       {
@@ -568,6 +713,102 @@
       }
     ],
     "name": "revokeRolePreapproval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "minSubmissions",
+        "type": "uint64"
+      }
+    ],
+    "name": "setBlockSpecimenMinSubmissionRequired",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "newBlockSpecimenReward",
+        "type": "uint128"
+      }
+    ],
+    "name": "setBlockSpecimenReward",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "newSessionDuration",
+        "type": "uint64"
+      }
+    ],
+    "name": "setBlockSpecimenSessionDuration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "chainId",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "maxSubmissions",
+        "type": "uint64"
+      }
+    ],
+    "name": "setMaxNumberOfHashesPer24H",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "minSubmissions",
+        "type": "uint64"
+      }
+    ],
+    "name": "setMinSubmissionsRequired",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "numberOfBlocks",
+        "type": "uint64"
+      }
+    ],
+    "name": "setNumberOfBlocksPer24H",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "quorum",
+        "type": "uint64"
+      }
+    ],
+    "name": "setQuorumThreshold",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -657,14 +898,9 @@
         "type": "uint64"
       },
       {
-        "internalType": "uint64",
-        "name": "specimenSize",
-        "type": "uint64"
-      },
-      {
-        "internalType": "uint64",
-        "name": "specimenLength",
-        "type": "uint64"
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
       },
       {
         "internalType": "bytes32",
@@ -678,45 +914,6 @@
       }
     ],
     "name": "submitBlockSpecimenProof",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint128",
-        "name": "newBlockSpecimenReward",
-        "type": "uint128"
-      }
-    ],
-    "name": "updateBlockSpecimenReward",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "newSessionDuration",
-        "type": "uint64"
-      }
-    ],
-    "name": "updateBlockSpecimenSessionDuration",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint64",
-        "name": "quorumThresholdNumerator",
-        "type": "uint64"
-      }
-    ],
-    "name": "updateQuorumThreshold",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/internal/proof/proofchain.go
+++ b/internal/proof/proofchain.go
@@ -30,7 +30,7 @@ var (
 
 // ProofChainMetaData contains all meta data concerning the ProofChain contract.
 var ProofChainMetaData = &bind.MetaData{
-	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"blockHeight\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"specimenSize\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"specimenLength\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"specimenHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"storageURL\",\"type\":\"string\"}],\"name\":\"BlockSpecimenProductionProofSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"blockHeight\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint128\",\"name\":\"reward\",\"type\":\"uint128\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"}],\"name\":\"BlockSpecimenRewardAwarded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint128\",\"name\":\"newBlockSpecimenRewardAllocation\",\"type\":\"uint128\"}],\"name\":\"BlockSpecimenRewardChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint128\",\"name\":\"blockHeight\",\"type\":\"uint128\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"proofHash\",\"type\":\"bytes32\"}],\"name\":\"BlockSpecimenSessionFinalized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"}],\"name\":\"OperatorStartedRole\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"}],\"name\":\"OperatorStoppedRole\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"previousAdminRole\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"newAdminRole\",\"type\":\"bytes32\"}],\"name\":\"RoleAdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleGranted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleRevoked\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"newSessionDuration\",\"type\":\"uint64\"}],\"name\":\"SpecimenSessionDurationChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"newQuorumThreshold\",\"type\":\"uint64\"}],\"name\":\"SpecimenSessionQuorumChanged\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"AUDITOR_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"BLOCK_SPECIMEN_PRODUCER_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"GOVERNANCE_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint128\",\"name\":\"\",\"type\":\"uint128\"}],\"name\":\"activeIDs\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"newRole\",\"type\":\"bytes32\"}],\"name\":\"addRoleType\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"uint128\",\"name\":\"commissionRate\",\"type\":\"uint128\"}],\"name\":\"addValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"blockHeight\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"definitiveSpecimenHash\",\"type\":\"bytes32\"}],\"name\":\"arbitrateBlockSpecimenSession\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"blockSpecimenQuorumThresholdNumerator\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"blockSpecimenRewardAllocation\",\"outputs\":[{\"internalType\":\"uint128\",\"name\":\"\",\"type\":\"uint128\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"blockSpecimenSessionDuration\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"}],\"name\":\"countOperatorsRoles\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"roleCount\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"},{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"name\":\"disableValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getRoleTypes\",\"outputs\":[{\"internalType\":\"bytes32[]\",\"name\":\"roleTypes\",\"type\":\"bytes32[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"grantRolePreapproval\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"initialOwner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"stakingContract\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"isPreapprovedForRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"}],\"name\":\"isSufficientlyStakedForRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"}],\"name\":\"removeOperator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"revokeRolePreapproval\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"uint128\",\"name\":\"newStakeAmount\",\"type\":\"uint128\"}],\"name\":\"setRequiredStakeForRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"stakingContractAddress\",\"type\":\"address\"}],\"name\":\"setStakingInterface\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"},{\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"}],\"name\":\"startOperatorRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"}],\"name\":\"stopOperatorRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"blockHeight\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"specimenSize\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"specimenLength\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"specimenHash\",\"type\":\"bytes32\"},{\"internalType\":\"string\",\"name\":\"storageURL\",\"type\":\"string\"}],\"name\":\"submitBlockSpecimenProof\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint128\",\"name\":\"newBlockSpecimenReward\",\"type\":\"uint128\"}],\"name\":\"updateBlockSpecimenReward\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"newSessionDuration\",\"type\":\"uint64\"}],\"name\":\"updateBlockSpecimenSessionDuration\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"quorumThresholdNumerator\",\"type\":\"uint64\"}],\"name\":\"updateQuorumThreshold\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"validatorIDs\",\"outputs\":[{\"internalType\":\"uint128\",\"name\":\"\",\"type\":\"uint128\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+	ABI: "[{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"newMaxNumberOfHashesPer24H\",\"type\":\"uint64\"}],\"name\":\"BlockSpecimenMaxNumberOfHashesPer24HChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint128\",\"name\":\"newBlockSpecimenMinSubmissionsRequired\",\"type\":\"uint128\"}],\"name\":\"BlockSpecimenMinSubmissionRequiredChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"blockHeight\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"blockHash\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"specimenHash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"string\",\"name\":\"storageURL\",\"type\":\"string\"},{\"indexed\":false,\"internalType\":\"uint128\",\"name\":\"submittedStake\",\"type\":\"uint128\"}],\"name\":\"BlockSpecimenProductionProofSubmitted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"blockHeight\",\"type\":\"uint64\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"blockhash\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"specimenhash\",\"type\":\"bytes32\"}],\"name\":\"BlockSpecimenRewardAwarded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint128\",\"name\":\"newBlockSpecimenRewardAllocation\",\"type\":\"uint128\"}],\"name\":\"BlockSpecimenRewardChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint128\",\"name\":\"blockHeight\",\"type\":\"uint128\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"proofHash\",\"type\":\"bytes32\"}],\"name\":\"BlockSpecimenSessionFinalized\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"uint128\",\"name\":\"newStakeRequirement\",\"type\":\"uint128\"}],\"name\":\"MinimumRequiredStakeChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"numberOfBlocks\",\"type\":\"uint64\"}],\"name\":\"NumberOfBlocksPer24HChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"}],\"name\":\"OperatorStartedRole\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"}],\"name\":\"OperatorStoppedRole\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"blockHeight\",\"type\":\"uint64\"}],\"name\":\"QuorumNotReached\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"previousAdminRole\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"newAdminRole\",\"type\":\"bytes32\"}],\"name\":\"RoleAdminChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleGranted\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"role\",\"type\":\"bytes32\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"sender\",\"type\":\"address\"}],\"name\":\"RoleRevoked\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"newSessionDuration\",\"type\":\"uint64\"}],\"name\":\"SpecimenSessionDurationChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"minSubmissions\",\"type\":\"uint64\"}],\"name\":\"SpecimenSessionMinSubmissionChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint64\",\"name\":\"newQuorumThreshold\",\"type\":\"uint64\"}],\"name\":\"SpecimenSessionQuorumChanged\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"address\",\"name\":\"newInterfaceAddress\",\"type\":\"address\"}],\"name\":\"StakingInterfaceChanged\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"AUDITOR_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"BLOCK_SPECIMEN_PRODUCER_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"GOVERNANCE_ROLE\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint128\",\"name\":\"\",\"type\":\"uint128\"}],\"name\":\"activeIDs\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"newRoleName\",\"type\":\"bytes32\"}],\"name\":\"addRoleType\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"validator\",\"type\":\"address\"},{\"internalType\":\"uint128\",\"name\":\"commissionRate\",\"type\":\"uint128\"}],\"name\":\"addValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"blockHeight\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"blockHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"definitiveSpecimenHash\",\"type\":\"bytes32\"}],\"name\":\"arbitrateBlockSpecimenSession\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"blockSpecimenQuorum\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"blockSpecimenRewardAllocation\",\"outputs\":[{\"internalType\":\"uint128\",\"name\":\"\",\"type\":\"uint128\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"blockSpecimenSessionDuration\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"}],\"name\":\"countOperatorsRoles\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"roleCount\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"},{\"internalType\":\"uint256\",\"name\":\"blockNumber\",\"type\":\"uint256\"}],\"name\":\"disableValidator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"blockHeight\",\"type\":\"uint64\"}],\"name\":\"finalizeAndRewardSpecimenSession\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getRoleTypes\",\"outputs\":[{\"internalType\":\"bytes32[]\",\"name\":\"roleTypes\",\"type\":\"bytes32[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"grantRolePreapproval\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"initialOwner\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"stakingContract\",\"type\":\"address\"}],\"name\":\"initialize\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"isPreapprovedForRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"}],\"name\":\"isSufficientlyStakedForRole\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"minSubmissionsRequired\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"}],\"name\":\"removeOperator\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"revokeRolePreapproval\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"minSubmissions\",\"type\":\"uint64\"}],\"name\":\"setBlockSpecimenMinSubmissionRequired\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint128\",\"name\":\"newBlockSpecimenReward\",\"type\":\"uint128\"}],\"name\":\"setBlockSpecimenReward\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"newSessionDuration\",\"type\":\"uint64\"}],\"name\":\"setBlockSpecimenSessionDuration\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"maxSubmissions\",\"type\":\"uint64\"}],\"name\":\"setMaxNumberOfHashesPer24H\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"minSubmissions\",\"type\":\"uint64\"}],\"name\":\"setMinSubmissionsRequired\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"numberOfBlocks\",\"type\":\"uint64\"}],\"name\":\"setNumberOfBlocksPer24H\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"quorum\",\"type\":\"uint64\"}],\"name\":\"setQuorumThreshold\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"uint128\",\"name\":\"newStakeAmount\",\"type\":\"uint128\"}],\"name\":\"setRequiredStakeForRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"stakingContractAddress\",\"type\":\"address\"}],\"name\":\"setStakingInterface\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"},{\"internalType\":\"address\",\"name\":\"operatorAddress\",\"type\":\"address\"}],\"name\":\"startOperatorRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"bytes32\",\"name\":\"roleName\",\"type\":\"bytes32\"},{\"internalType\":\"uint128\",\"name\":\"validatorId\",\"type\":\"uint128\"}],\"name\":\"stopOperatorRole\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"chainId\",\"type\":\"uint64\"},{\"internalType\":\"uint64\",\"name\":\"blockHeight\",\"type\":\"uint64\"},{\"internalType\":\"bytes32\",\"name\":\"blockHash\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"specimenHash\",\"type\":\"bytes32\"},{\"internalType\":\"string\",\"name\":\"storageURL\",\"type\":\"string\"}],\"name\":\"submitBlockSpecimenProof\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"name\":\"validatorIDs\",\"outputs\":[{\"internalType\":\"uint128\",\"name\":\"\",\"type\":\"uint128\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
 }
 
 // ProofChainABI is the input ABI used to generate the binding from.
@@ -303,12 +303,12 @@ func (_ProofChain *ProofChainCallerSession) ActiveIDs(arg0 *big.Int) (bool, erro
 	return _ProofChain.Contract.ActiveIDs(&_ProofChain.CallOpts, arg0)
 }
 
-// BlockSpecimenQuorumThresholdNumerator is a free data retrieval call binding the contract method 0x0a5d288f.
+// BlockSpecimenQuorum is a free data retrieval call binding the contract method 0x96df32b5.
 //
-// Solidity: function blockSpecimenQuorumThresholdNumerator() view returns(uint64)
-func (_ProofChain *ProofChainCaller) BlockSpecimenQuorumThresholdNumerator(opts *bind.CallOpts) (uint64, error) {
+// Solidity: function blockSpecimenQuorum() view returns(uint64)
+func (_ProofChain *ProofChainCaller) BlockSpecimenQuorum(opts *bind.CallOpts) (uint64, error) {
 	var out []interface{}
-	err := _ProofChain.contract.Call(opts, &out, "blockSpecimenQuorumThresholdNumerator")
+	err := _ProofChain.contract.Call(opts, &out, "blockSpecimenQuorum")
 
 	if err != nil {
 		return *new(uint64), err
@@ -320,18 +320,18 @@ func (_ProofChain *ProofChainCaller) BlockSpecimenQuorumThresholdNumerator(opts 
 
 }
 
-// BlockSpecimenQuorumThresholdNumerator is a free data retrieval call binding the contract method 0x0a5d288f.
+// BlockSpecimenQuorum is a free data retrieval call binding the contract method 0x96df32b5.
 //
-// Solidity: function blockSpecimenQuorumThresholdNumerator() view returns(uint64)
-func (_ProofChain *ProofChainSession) BlockSpecimenQuorumThresholdNumerator() (uint64, error) {
-	return _ProofChain.Contract.BlockSpecimenQuorumThresholdNumerator(&_ProofChain.CallOpts)
+// Solidity: function blockSpecimenQuorum() view returns(uint64)
+func (_ProofChain *ProofChainSession) BlockSpecimenQuorum() (uint64, error) {
+	return _ProofChain.Contract.BlockSpecimenQuorum(&_ProofChain.CallOpts)
 }
 
-// BlockSpecimenQuorumThresholdNumerator is a free data retrieval call binding the contract method 0x0a5d288f.
+// BlockSpecimenQuorum is a free data retrieval call binding the contract method 0x96df32b5.
 //
-// Solidity: function blockSpecimenQuorumThresholdNumerator() view returns(uint64)
-func (_ProofChain *ProofChainCallerSession) BlockSpecimenQuorumThresholdNumerator() (uint64, error) {
-	return _ProofChain.Contract.BlockSpecimenQuorumThresholdNumerator(&_ProofChain.CallOpts)
+// Solidity: function blockSpecimenQuorum() view returns(uint64)
+func (_ProofChain *ProofChainCallerSession) BlockSpecimenQuorum() (uint64, error) {
+	return _ProofChain.Contract.BlockSpecimenQuorum(&_ProofChain.CallOpts)
 }
 
 // BlockSpecimenRewardAllocation is a free data retrieval call binding the contract method 0xb143d7db.
@@ -520,6 +520,37 @@ func (_ProofChain *ProofChainCallerSession) IsSufficientlyStakedForRole(roleName
 	return _ProofChain.Contract.IsSufficientlyStakedForRole(&_ProofChain.CallOpts, roleName, validatorId)
 }
 
+// MinSubmissionsRequired is a free data retrieval call binding the contract method 0x6d261e00.
+//
+// Solidity: function minSubmissionsRequired() view returns(uint64)
+func (_ProofChain *ProofChainCaller) MinSubmissionsRequired(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _ProofChain.contract.Call(opts, &out, "minSubmissionsRequired")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+// MinSubmissionsRequired is a free data retrieval call binding the contract method 0x6d261e00.
+//
+// Solidity: function minSubmissionsRequired() view returns(uint64)
+func (_ProofChain *ProofChainSession) MinSubmissionsRequired() (uint64, error) {
+	return _ProofChain.Contract.MinSubmissionsRequired(&_ProofChain.CallOpts)
+}
+
+// MinSubmissionsRequired is a free data retrieval call binding the contract method 0x6d261e00.
+//
+// Solidity: function minSubmissionsRequired() view returns(uint64)
+func (_ProofChain *ProofChainCallerSession) MinSubmissionsRequired() (uint64, error) {
+	return _ProofChain.Contract.MinSubmissionsRequired(&_ProofChain.CallOpts)
+}
+
 // ValidatorIDs is a free data retrieval call binding the contract method 0x0d92f4ed.
 //
 // Solidity: function validatorIDs(address ) view returns(uint128)
@@ -553,23 +584,23 @@ func (_ProofChain *ProofChainCallerSession) ValidatorIDs(arg0 common.Address) (*
 
 // AddRoleType is a paid mutator transaction binding the contract method 0xcdb1c112.
 //
-// Solidity: function addRoleType(bytes32 newRole) returns()
-func (_ProofChain *ProofChainTransactor) AddRoleType(opts *bind.TransactOpts, newRole [32]byte) (*types.Transaction, error) {
-	return _ProofChain.contract.Transact(opts, "addRoleType", newRole)
+// Solidity: function addRoleType(bytes32 newRoleName) returns()
+func (_ProofChain *ProofChainTransactor) AddRoleType(opts *bind.TransactOpts, newRoleName [32]byte) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "addRoleType", newRoleName)
 }
 
 // AddRoleType is a paid mutator transaction binding the contract method 0xcdb1c112.
 //
-// Solidity: function addRoleType(bytes32 newRole) returns()
-func (_ProofChain *ProofChainSession) AddRoleType(newRole [32]byte) (*types.Transaction, error) {
-	return _ProofChain.Contract.AddRoleType(&_ProofChain.TransactOpts, newRole)
+// Solidity: function addRoleType(bytes32 newRoleName) returns()
+func (_ProofChain *ProofChainSession) AddRoleType(newRoleName [32]byte) (*types.Transaction, error) {
+	return _ProofChain.Contract.AddRoleType(&_ProofChain.TransactOpts, newRoleName)
 }
 
 // AddRoleType is a paid mutator transaction binding the contract method 0xcdb1c112.
 //
-// Solidity: function addRoleType(bytes32 newRole) returns()
-func (_ProofChain *ProofChainTransactorSession) AddRoleType(newRole [32]byte) (*types.Transaction, error) {
-	return _ProofChain.Contract.AddRoleType(&_ProofChain.TransactOpts, newRole)
+// Solidity: function addRoleType(bytes32 newRoleName) returns()
+func (_ProofChain *ProofChainTransactorSession) AddRoleType(newRoleName [32]byte) (*types.Transaction, error) {
+	return _ProofChain.Contract.AddRoleType(&_ProofChain.TransactOpts, newRoleName)
 }
 
 // AddValidator is a paid mutator transaction binding the contract method 0xa2e7e441.
@@ -593,25 +624,25 @@ func (_ProofChain *ProofChainTransactorSession) AddValidator(validator common.Ad
 	return _ProofChain.Contract.AddValidator(&_ProofChain.TransactOpts, validator, commissionRate)
 }
 
-// ArbitrateBlockSpecimenSession is a paid mutator transaction binding the contract method 0x6a667fdd.
+// ArbitrateBlockSpecimenSession is a paid mutator transaction binding the contract method 0x4414beeb.
 //
-// Solidity: function arbitrateBlockSpecimenSession(uint64 chainId, uint64 blockHeight, bytes32 definitiveSpecimenHash) returns()
-func (_ProofChain *ProofChainTransactor) ArbitrateBlockSpecimenSession(opts *bind.TransactOpts, chainId uint64, blockHeight uint64, definitiveSpecimenHash [32]byte) (*types.Transaction, error) {
-	return _ProofChain.contract.Transact(opts, "arbitrateBlockSpecimenSession", chainId, blockHeight, definitiveSpecimenHash)
+// Solidity: function arbitrateBlockSpecimenSession(uint64 chainId, uint64 blockHeight, bytes32 blockHash, bytes32 definitiveSpecimenHash) returns()
+func (_ProofChain *ProofChainTransactor) ArbitrateBlockSpecimenSession(opts *bind.TransactOpts, chainId uint64, blockHeight uint64, blockHash [32]byte, definitiveSpecimenHash [32]byte) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "arbitrateBlockSpecimenSession", chainId, blockHeight, blockHash, definitiveSpecimenHash)
 }
 
-// ArbitrateBlockSpecimenSession is a paid mutator transaction binding the contract method 0x6a667fdd.
+// ArbitrateBlockSpecimenSession is a paid mutator transaction binding the contract method 0x4414beeb.
 //
-// Solidity: function arbitrateBlockSpecimenSession(uint64 chainId, uint64 blockHeight, bytes32 definitiveSpecimenHash) returns()
-func (_ProofChain *ProofChainSession) ArbitrateBlockSpecimenSession(chainId uint64, blockHeight uint64, definitiveSpecimenHash [32]byte) (*types.Transaction, error) {
-	return _ProofChain.Contract.ArbitrateBlockSpecimenSession(&_ProofChain.TransactOpts, chainId, blockHeight, definitiveSpecimenHash)
+// Solidity: function arbitrateBlockSpecimenSession(uint64 chainId, uint64 blockHeight, bytes32 blockHash, bytes32 definitiveSpecimenHash) returns()
+func (_ProofChain *ProofChainSession) ArbitrateBlockSpecimenSession(chainId uint64, blockHeight uint64, blockHash [32]byte, definitiveSpecimenHash [32]byte) (*types.Transaction, error) {
+	return _ProofChain.Contract.ArbitrateBlockSpecimenSession(&_ProofChain.TransactOpts, chainId, blockHeight, blockHash, definitiveSpecimenHash)
 }
 
-// ArbitrateBlockSpecimenSession is a paid mutator transaction binding the contract method 0x6a667fdd.
+// ArbitrateBlockSpecimenSession is a paid mutator transaction binding the contract method 0x4414beeb.
 //
-// Solidity: function arbitrateBlockSpecimenSession(uint64 chainId, uint64 blockHeight, bytes32 definitiveSpecimenHash) returns()
-func (_ProofChain *ProofChainTransactorSession) ArbitrateBlockSpecimenSession(chainId uint64, blockHeight uint64, definitiveSpecimenHash [32]byte) (*types.Transaction, error) {
-	return _ProofChain.Contract.ArbitrateBlockSpecimenSession(&_ProofChain.TransactOpts, chainId, blockHeight, definitiveSpecimenHash)
+// Solidity: function arbitrateBlockSpecimenSession(uint64 chainId, uint64 blockHeight, bytes32 blockHash, bytes32 definitiveSpecimenHash) returns()
+func (_ProofChain *ProofChainTransactorSession) ArbitrateBlockSpecimenSession(chainId uint64, blockHeight uint64, blockHash [32]byte, definitiveSpecimenHash [32]byte) (*types.Transaction, error) {
+	return _ProofChain.Contract.ArbitrateBlockSpecimenSession(&_ProofChain.TransactOpts, chainId, blockHeight, blockHash, definitiveSpecimenHash)
 }
 
 // DisableValidator is a paid mutator transaction binding the contract method 0xad9e91ee.
@@ -635,25 +666,46 @@ func (_ProofChain *ProofChainTransactorSession) DisableValidator(validatorId *bi
 	return _ProofChain.Contract.DisableValidator(&_ProofChain.TransactOpts, validatorId, blockNumber)
 }
 
-// GrantRolePreapproval is a paid mutator transaction binding the contract method 0x5ff2bfa0.
+// FinalizeAndRewardSpecimenSession is a paid mutator transaction binding the contract method 0x8ecd30bc.
 //
-// Solidity: function grantRolePreapproval(bytes32 role, address account) returns()
-func (_ProofChain *ProofChainTransactor) GrantRolePreapproval(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
-	return _ProofChain.contract.Transact(opts, "grantRolePreapproval", role, account)
+// Solidity: function finalizeAndRewardSpecimenSession(uint64 chainId, uint64 blockHeight) returns()
+func (_ProofChain *ProofChainTransactor) FinalizeAndRewardSpecimenSession(opts *bind.TransactOpts, chainId uint64, blockHeight uint64) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "finalizeAndRewardSpecimenSession", chainId, blockHeight)
+}
+
+// FinalizeAndRewardSpecimenSession is a paid mutator transaction binding the contract method 0x8ecd30bc.
+//
+// Solidity: function finalizeAndRewardSpecimenSession(uint64 chainId, uint64 blockHeight) returns()
+func (_ProofChain *ProofChainSession) FinalizeAndRewardSpecimenSession(chainId uint64, blockHeight uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.FinalizeAndRewardSpecimenSession(&_ProofChain.TransactOpts, chainId, blockHeight)
+}
+
+// FinalizeAndRewardSpecimenSession is a paid mutator transaction binding the contract method 0x8ecd30bc.
+//
+// Solidity: function finalizeAndRewardSpecimenSession(uint64 chainId, uint64 blockHeight) returns()
+func (_ProofChain *ProofChainTransactorSession) FinalizeAndRewardSpecimenSession(chainId uint64, blockHeight uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.FinalizeAndRewardSpecimenSession(&_ProofChain.TransactOpts, chainId, blockHeight)
 }
 
 // GrantRolePreapproval is a paid mutator transaction binding the contract method 0x5ff2bfa0.
 //
-// Solidity: function grantRolePreapproval(bytes32 role, address account) returns()
-func (_ProofChain *ProofChainSession) GrantRolePreapproval(role [32]byte, account common.Address) (*types.Transaction, error) {
-	return _ProofChain.Contract.GrantRolePreapproval(&_ProofChain.TransactOpts, role, account)
+// Solidity: function grantRolePreapproval(bytes32 roleName, address account) returns()
+func (_ProofChain *ProofChainTransactor) GrantRolePreapproval(opts *bind.TransactOpts, roleName [32]byte, account common.Address) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "grantRolePreapproval", roleName, account)
 }
 
 // GrantRolePreapproval is a paid mutator transaction binding the contract method 0x5ff2bfa0.
 //
-// Solidity: function grantRolePreapproval(bytes32 role, address account) returns()
-func (_ProofChain *ProofChainTransactorSession) GrantRolePreapproval(role [32]byte, account common.Address) (*types.Transaction, error) {
-	return _ProofChain.Contract.GrantRolePreapproval(&_ProofChain.TransactOpts, role, account)
+// Solidity: function grantRolePreapproval(bytes32 roleName, address account) returns()
+func (_ProofChain *ProofChainSession) GrantRolePreapproval(roleName [32]byte, account common.Address) (*types.Transaction, error) {
+	return _ProofChain.Contract.GrantRolePreapproval(&_ProofChain.TransactOpts, roleName, account)
+}
+
+// GrantRolePreapproval is a paid mutator transaction binding the contract method 0x5ff2bfa0.
+//
+// Solidity: function grantRolePreapproval(bytes32 roleName, address account) returns()
+func (_ProofChain *ProofChainTransactorSession) GrantRolePreapproval(roleName [32]byte, account common.Address) (*types.Transaction, error) {
+	return _ProofChain.Contract.GrantRolePreapproval(&_ProofChain.TransactOpts, roleName, account)
 }
 
 // Initialize is a paid mutator transaction binding the contract method 0x485cc955.
@@ -700,23 +752,170 @@ func (_ProofChain *ProofChainTransactorSession) RemoveOperator(validatorId *big.
 
 // RevokeRolePreapproval is a paid mutator transaction binding the contract method 0x75d37c73.
 //
-// Solidity: function revokeRolePreapproval(bytes32 role, address account) returns()
-func (_ProofChain *ProofChainTransactor) RevokeRolePreapproval(opts *bind.TransactOpts, role [32]byte, account common.Address) (*types.Transaction, error) {
-	return _ProofChain.contract.Transact(opts, "revokeRolePreapproval", role, account)
+// Solidity: function revokeRolePreapproval(bytes32 roleName, address account) returns()
+func (_ProofChain *ProofChainTransactor) RevokeRolePreapproval(opts *bind.TransactOpts, roleName [32]byte, account common.Address) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "revokeRolePreapproval", roleName, account)
 }
 
 // RevokeRolePreapproval is a paid mutator transaction binding the contract method 0x75d37c73.
 //
-// Solidity: function revokeRolePreapproval(bytes32 role, address account) returns()
-func (_ProofChain *ProofChainSession) RevokeRolePreapproval(role [32]byte, account common.Address) (*types.Transaction, error) {
-	return _ProofChain.Contract.RevokeRolePreapproval(&_ProofChain.TransactOpts, role, account)
+// Solidity: function revokeRolePreapproval(bytes32 roleName, address account) returns()
+func (_ProofChain *ProofChainSession) RevokeRolePreapproval(roleName [32]byte, account common.Address) (*types.Transaction, error) {
+	return _ProofChain.Contract.RevokeRolePreapproval(&_ProofChain.TransactOpts, roleName, account)
 }
 
 // RevokeRolePreapproval is a paid mutator transaction binding the contract method 0x75d37c73.
 //
-// Solidity: function revokeRolePreapproval(bytes32 role, address account) returns()
-func (_ProofChain *ProofChainTransactorSession) RevokeRolePreapproval(role [32]byte, account common.Address) (*types.Transaction, error) {
-	return _ProofChain.Contract.RevokeRolePreapproval(&_ProofChain.TransactOpts, role, account)
+// Solidity: function revokeRolePreapproval(bytes32 roleName, address account) returns()
+func (_ProofChain *ProofChainTransactorSession) RevokeRolePreapproval(roleName [32]byte, account common.Address) (*types.Transaction, error) {
+	return _ProofChain.Contract.RevokeRolePreapproval(&_ProofChain.TransactOpts, roleName, account)
+}
+
+// SetBlockSpecimenMinSubmissionRequired is a paid mutator transaction binding the contract method 0x7432d8dd.
+//
+// Solidity: function setBlockSpecimenMinSubmissionRequired(uint64 minSubmissions) returns()
+func (_ProofChain *ProofChainTransactor) SetBlockSpecimenMinSubmissionRequired(opts *bind.TransactOpts, minSubmissions uint64) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "setBlockSpecimenMinSubmissionRequired", minSubmissions)
+}
+
+// SetBlockSpecimenMinSubmissionRequired is a paid mutator transaction binding the contract method 0x7432d8dd.
+//
+// Solidity: function setBlockSpecimenMinSubmissionRequired(uint64 minSubmissions) returns()
+func (_ProofChain *ProofChainSession) SetBlockSpecimenMinSubmissionRequired(minSubmissions uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetBlockSpecimenMinSubmissionRequired(&_ProofChain.TransactOpts, minSubmissions)
+}
+
+// SetBlockSpecimenMinSubmissionRequired is a paid mutator transaction binding the contract method 0x7432d8dd.
+//
+// Solidity: function setBlockSpecimenMinSubmissionRequired(uint64 minSubmissions) returns()
+func (_ProofChain *ProofChainTransactorSession) SetBlockSpecimenMinSubmissionRequired(minSubmissions uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetBlockSpecimenMinSubmissionRequired(&_ProofChain.TransactOpts, minSubmissions)
+}
+
+// SetBlockSpecimenReward is a paid mutator transaction binding the contract method 0x89587f05.
+//
+// Solidity: function setBlockSpecimenReward(uint128 newBlockSpecimenReward) returns()
+func (_ProofChain *ProofChainTransactor) SetBlockSpecimenReward(opts *bind.TransactOpts, newBlockSpecimenReward *big.Int) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "setBlockSpecimenReward", newBlockSpecimenReward)
+}
+
+// SetBlockSpecimenReward is a paid mutator transaction binding the contract method 0x89587f05.
+//
+// Solidity: function setBlockSpecimenReward(uint128 newBlockSpecimenReward) returns()
+func (_ProofChain *ProofChainSession) SetBlockSpecimenReward(newBlockSpecimenReward *big.Int) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetBlockSpecimenReward(&_ProofChain.TransactOpts, newBlockSpecimenReward)
+}
+
+// SetBlockSpecimenReward is a paid mutator transaction binding the contract method 0x89587f05.
+//
+// Solidity: function setBlockSpecimenReward(uint128 newBlockSpecimenReward) returns()
+func (_ProofChain *ProofChainTransactorSession) SetBlockSpecimenReward(newBlockSpecimenReward *big.Int) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetBlockSpecimenReward(&_ProofChain.TransactOpts, newBlockSpecimenReward)
+}
+
+// SetBlockSpecimenSessionDuration is a paid mutator transaction binding the contract method 0x67d07ad7.
+//
+// Solidity: function setBlockSpecimenSessionDuration(uint64 newSessionDuration) returns()
+func (_ProofChain *ProofChainTransactor) SetBlockSpecimenSessionDuration(opts *bind.TransactOpts, newSessionDuration uint64) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "setBlockSpecimenSessionDuration", newSessionDuration)
+}
+
+// SetBlockSpecimenSessionDuration is a paid mutator transaction binding the contract method 0x67d07ad7.
+//
+// Solidity: function setBlockSpecimenSessionDuration(uint64 newSessionDuration) returns()
+func (_ProofChain *ProofChainSession) SetBlockSpecimenSessionDuration(newSessionDuration uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetBlockSpecimenSessionDuration(&_ProofChain.TransactOpts, newSessionDuration)
+}
+
+// SetBlockSpecimenSessionDuration is a paid mutator transaction binding the contract method 0x67d07ad7.
+//
+// Solidity: function setBlockSpecimenSessionDuration(uint64 newSessionDuration) returns()
+func (_ProofChain *ProofChainTransactorSession) SetBlockSpecimenSessionDuration(newSessionDuration uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetBlockSpecimenSessionDuration(&_ProofChain.TransactOpts, newSessionDuration)
+}
+
+// SetMaxNumberOfHashesPer24H is a paid mutator transaction binding the contract method 0xc700c43b.
+//
+// Solidity: function setMaxNumberOfHashesPer24H(uint64 chainId, uint64 maxSubmissions) returns()
+func (_ProofChain *ProofChainTransactor) SetMaxNumberOfHashesPer24H(opts *bind.TransactOpts, chainId uint64, maxSubmissions uint64) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "setMaxNumberOfHashesPer24H", chainId, maxSubmissions)
+}
+
+// SetMaxNumberOfHashesPer24H is a paid mutator transaction binding the contract method 0xc700c43b.
+//
+// Solidity: function setMaxNumberOfHashesPer24H(uint64 chainId, uint64 maxSubmissions) returns()
+func (_ProofChain *ProofChainSession) SetMaxNumberOfHashesPer24H(chainId uint64, maxSubmissions uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetMaxNumberOfHashesPer24H(&_ProofChain.TransactOpts, chainId, maxSubmissions)
+}
+
+// SetMaxNumberOfHashesPer24H is a paid mutator transaction binding the contract method 0xc700c43b.
+//
+// Solidity: function setMaxNumberOfHashesPer24H(uint64 chainId, uint64 maxSubmissions) returns()
+func (_ProofChain *ProofChainTransactorSession) SetMaxNumberOfHashesPer24H(chainId uint64, maxSubmissions uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetMaxNumberOfHashesPer24H(&_ProofChain.TransactOpts, chainId, maxSubmissions)
+}
+
+// SetMinSubmissionsRequired is a paid mutator transaction binding the contract method 0x93742b56.
+//
+// Solidity: function setMinSubmissionsRequired(uint64 minSubmissions) returns()
+func (_ProofChain *ProofChainTransactor) SetMinSubmissionsRequired(opts *bind.TransactOpts, minSubmissions uint64) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "setMinSubmissionsRequired", minSubmissions)
+}
+
+// SetMinSubmissionsRequired is a paid mutator transaction binding the contract method 0x93742b56.
+//
+// Solidity: function setMinSubmissionsRequired(uint64 minSubmissions) returns()
+func (_ProofChain *ProofChainSession) SetMinSubmissionsRequired(minSubmissions uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetMinSubmissionsRequired(&_ProofChain.TransactOpts, minSubmissions)
+}
+
+// SetMinSubmissionsRequired is a paid mutator transaction binding the contract method 0x93742b56.
+//
+// Solidity: function setMinSubmissionsRequired(uint64 minSubmissions) returns()
+func (_ProofChain *ProofChainTransactorSession) SetMinSubmissionsRequired(minSubmissions uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetMinSubmissionsRequired(&_ProofChain.TransactOpts, minSubmissions)
+}
+
+// SetNumberOfBlocksPer24H is a paid mutator transaction binding the contract method 0xf883465a.
+//
+// Solidity: function setNumberOfBlocksPer24H(uint64 numberOfBlocks) returns()
+func (_ProofChain *ProofChainTransactor) SetNumberOfBlocksPer24H(opts *bind.TransactOpts, numberOfBlocks uint64) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "setNumberOfBlocksPer24H", numberOfBlocks)
+}
+
+// SetNumberOfBlocksPer24H is a paid mutator transaction binding the contract method 0xf883465a.
+//
+// Solidity: function setNumberOfBlocksPer24H(uint64 numberOfBlocks) returns()
+func (_ProofChain *ProofChainSession) SetNumberOfBlocksPer24H(numberOfBlocks uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetNumberOfBlocksPer24H(&_ProofChain.TransactOpts, numberOfBlocks)
+}
+
+// SetNumberOfBlocksPer24H is a paid mutator transaction binding the contract method 0xf883465a.
+//
+// Solidity: function setNumberOfBlocksPer24H(uint64 numberOfBlocks) returns()
+func (_ProofChain *ProofChainTransactorSession) SetNumberOfBlocksPer24H(numberOfBlocks uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetNumberOfBlocksPer24H(&_ProofChain.TransactOpts, numberOfBlocks)
+}
+
+// SetQuorumThreshold is a paid mutator transaction binding the contract method 0x7442f33a.
+//
+// Solidity: function setQuorumThreshold(uint64 quorum) returns()
+func (_ProofChain *ProofChainTransactor) SetQuorumThreshold(opts *bind.TransactOpts, quorum uint64) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "setQuorumThreshold", quorum)
+}
+
+// SetQuorumThreshold is a paid mutator transaction binding the contract method 0x7442f33a.
+//
+// Solidity: function setQuorumThreshold(uint64 quorum) returns()
+func (_ProofChain *ProofChainSession) SetQuorumThreshold(quorum uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetQuorumThreshold(&_ProofChain.TransactOpts, quorum)
+}
+
+// SetQuorumThreshold is a paid mutator transaction binding the contract method 0x7442f33a.
+//
+// Solidity: function setQuorumThreshold(uint64 quorum) returns()
+func (_ProofChain *ProofChainTransactorSession) SetQuorumThreshold(quorum uint64) (*types.Transaction, error) {
+	return _ProofChain.Contract.SetQuorumThreshold(&_ProofChain.TransactOpts, quorum)
 }
 
 // SetRequiredStakeForRole is a paid mutator transaction binding the contract method 0x4a40372a.
@@ -803,88 +1002,304 @@ func (_ProofChain *ProofChainTransactorSession) StopOperatorRole(roleName [32]by
 	return _ProofChain.Contract.StopOperatorRole(&_ProofChain.TransactOpts, roleName, validatorId)
 }
 
-// SubmitBlockSpecimenProof is a paid mutator transaction binding the contract method 0xa5b14168.
+// SubmitBlockSpecimenProof is a paid mutator transaction binding the contract method 0x151fd8f3.
 //
-// Solidity: function submitBlockSpecimenProof(uint64 chainId, uint64 blockHeight, uint64 specimenSize, uint64 specimenLength, bytes32 specimenHash, string storageURL) returns()
-func (_ProofChain *ProofChainTransactor) SubmitBlockSpecimenProof(opts *bind.TransactOpts, chainId uint64, blockHeight uint64, specimenSize uint64, specimenLength uint64, specimenHash [32]byte, storageURL string) (*types.Transaction, error) {
-	return _ProofChain.contract.Transact(opts, "submitBlockSpecimenProof", chainId, blockHeight, specimenSize, specimenLength, specimenHash, storageURL)
+// Solidity: function submitBlockSpecimenProof(uint64 chainId, uint64 blockHeight, bytes32 blockHash, bytes32 specimenHash, string storageURL) returns()
+func (_ProofChain *ProofChainTransactor) SubmitBlockSpecimenProof(opts *bind.TransactOpts, chainId uint64, blockHeight uint64, blockHash [32]byte, specimenHash [32]byte, storageURL string) (*types.Transaction, error) {
+	return _ProofChain.contract.Transact(opts, "submitBlockSpecimenProof", chainId, blockHeight, blockHash, specimenHash, storageURL)
 }
 
-// SubmitBlockSpecimenProof is a paid mutator transaction binding the contract method 0xa5b14168.
+// SubmitBlockSpecimenProof is a paid mutator transaction binding the contract method 0x151fd8f3.
 //
-// Solidity: function submitBlockSpecimenProof(uint64 chainId, uint64 blockHeight, uint64 specimenSize, uint64 specimenLength, bytes32 specimenHash, string storageURL) returns()
-func (_ProofChain *ProofChainSession) SubmitBlockSpecimenProof(chainId uint64, blockHeight uint64, specimenSize uint64, specimenLength uint64, specimenHash [32]byte, storageURL string) (*types.Transaction, error) {
-	return _ProofChain.Contract.SubmitBlockSpecimenProof(&_ProofChain.TransactOpts, chainId, blockHeight, specimenSize, specimenLength, specimenHash, storageURL)
+// Solidity: function submitBlockSpecimenProof(uint64 chainId, uint64 blockHeight, bytes32 blockHash, bytes32 specimenHash, string storageURL) returns()
+func (_ProofChain *ProofChainSession) SubmitBlockSpecimenProof(chainId uint64, blockHeight uint64, blockHash [32]byte, specimenHash [32]byte, storageURL string) (*types.Transaction, error) {
+	return _ProofChain.Contract.SubmitBlockSpecimenProof(&_ProofChain.TransactOpts, chainId, blockHeight, blockHash, specimenHash, storageURL)
 }
 
-// SubmitBlockSpecimenProof is a paid mutator transaction binding the contract method 0xa5b14168.
+// SubmitBlockSpecimenProof is a paid mutator transaction binding the contract method 0x151fd8f3.
 //
-// Solidity: function submitBlockSpecimenProof(uint64 chainId, uint64 blockHeight, uint64 specimenSize, uint64 specimenLength, bytes32 specimenHash, string storageURL) returns()
-func (_ProofChain *ProofChainTransactorSession) SubmitBlockSpecimenProof(chainId uint64, blockHeight uint64, specimenSize uint64, specimenLength uint64, specimenHash [32]byte, storageURL string) (*types.Transaction, error) {
-	return _ProofChain.Contract.SubmitBlockSpecimenProof(&_ProofChain.TransactOpts, chainId, blockHeight, specimenSize, specimenLength, specimenHash, storageURL)
+// Solidity: function submitBlockSpecimenProof(uint64 chainId, uint64 blockHeight, bytes32 blockHash, bytes32 specimenHash, string storageURL) returns()
+func (_ProofChain *ProofChainTransactorSession) SubmitBlockSpecimenProof(chainId uint64, blockHeight uint64, blockHash [32]byte, specimenHash [32]byte, storageURL string) (*types.Transaction, error) {
+	return _ProofChain.Contract.SubmitBlockSpecimenProof(&_ProofChain.TransactOpts, chainId, blockHeight, blockHash, specimenHash, storageURL)
 }
 
-// UpdateBlockSpecimenReward is a paid mutator transaction binding the contract method 0xec7d3882.
-//
-// Solidity: function updateBlockSpecimenReward(uint128 newBlockSpecimenReward) returns()
-func (_ProofChain *ProofChainTransactor) UpdateBlockSpecimenReward(opts *bind.TransactOpts, newBlockSpecimenReward *big.Int) (*types.Transaction, error) {
-	return _ProofChain.contract.Transact(opts, "updateBlockSpecimenReward", newBlockSpecimenReward)
+// ProofChainBlockSpecimenMaxNumberOfHashesPer24HChangedIterator is returned from FilterBlockSpecimenMaxNumberOfHashesPer24HChanged and is used to iterate over the raw logs and unpacked data for BlockSpecimenMaxNumberOfHashesPer24HChanged events raised by the ProofChain contract.
+type ProofChainBlockSpecimenMaxNumberOfHashesPer24HChangedIterator struct {
+	Event *ProofChainBlockSpecimenMaxNumberOfHashesPer24HChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
 }
 
-// UpdateBlockSpecimenReward is a paid mutator transaction binding the contract method 0xec7d3882.
-//
-// Solidity: function updateBlockSpecimenReward(uint128 newBlockSpecimenReward) returns()
-func (_ProofChain *ProofChainSession) UpdateBlockSpecimenReward(newBlockSpecimenReward *big.Int) (*types.Transaction, error) {
-	return _ProofChain.Contract.UpdateBlockSpecimenReward(&_ProofChain.TransactOpts, newBlockSpecimenReward)
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ProofChainBlockSpecimenMaxNumberOfHashesPer24HChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ProofChainBlockSpecimenMaxNumberOfHashesPer24HChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ProofChainBlockSpecimenMaxNumberOfHashesPer24HChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
 }
 
-// UpdateBlockSpecimenReward is a paid mutator transaction binding the contract method 0xec7d3882.
-//
-// Solidity: function updateBlockSpecimenReward(uint128 newBlockSpecimenReward) returns()
-func (_ProofChain *ProofChainTransactorSession) UpdateBlockSpecimenReward(newBlockSpecimenReward *big.Int) (*types.Transaction, error) {
-	return _ProofChain.Contract.UpdateBlockSpecimenReward(&_ProofChain.TransactOpts, newBlockSpecimenReward)
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ProofChainBlockSpecimenMaxNumberOfHashesPer24HChangedIterator) Error() error {
+	return it.fail
 }
 
-// UpdateBlockSpecimenSessionDuration is a paid mutator transaction binding the contract method 0x1ae83023.
-//
-// Solidity: function updateBlockSpecimenSessionDuration(uint64 newSessionDuration) returns()
-func (_ProofChain *ProofChainTransactor) UpdateBlockSpecimenSessionDuration(opts *bind.TransactOpts, newSessionDuration uint64) (*types.Transaction, error) {
-	return _ProofChain.contract.Transact(opts, "updateBlockSpecimenSessionDuration", newSessionDuration)
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ProofChainBlockSpecimenMaxNumberOfHashesPer24HChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
 }
 
-// UpdateBlockSpecimenSessionDuration is a paid mutator transaction binding the contract method 0x1ae83023.
-//
-// Solidity: function updateBlockSpecimenSessionDuration(uint64 newSessionDuration) returns()
-func (_ProofChain *ProofChainSession) UpdateBlockSpecimenSessionDuration(newSessionDuration uint64) (*types.Transaction, error) {
-	return _ProofChain.Contract.UpdateBlockSpecimenSessionDuration(&_ProofChain.TransactOpts, newSessionDuration)
+// ProofChainBlockSpecimenMaxNumberOfHashesPer24HChanged represents a BlockSpecimenMaxNumberOfHashesPer24HChanged event raised by the ProofChain contract.
+type ProofChainBlockSpecimenMaxNumberOfHashesPer24HChanged struct {
+	ChainId                    uint64
+	NewMaxNumberOfHashesPer24H uint64
+	Raw                        types.Log // Blockchain specific contextual infos
 }
 
-// UpdateBlockSpecimenSessionDuration is a paid mutator transaction binding the contract method 0x1ae83023.
+// FilterBlockSpecimenMaxNumberOfHashesPer24HChanged is a free log retrieval operation binding the contract event 0xcd51a09527f1fdcb091e787cf5c06a462c010eaef61de7b7c3904916d95a4abd.
 //
-// Solidity: function updateBlockSpecimenSessionDuration(uint64 newSessionDuration) returns()
-func (_ProofChain *ProofChainTransactorSession) UpdateBlockSpecimenSessionDuration(newSessionDuration uint64) (*types.Transaction, error) {
-	return _ProofChain.Contract.UpdateBlockSpecimenSessionDuration(&_ProofChain.TransactOpts, newSessionDuration)
+// Solidity: event BlockSpecimenMaxNumberOfHashesPer24HChanged(uint64 indexed chainId, uint64 newMaxNumberOfHashesPer24H)
+func (_ProofChain *ProofChainFilterer) FilterBlockSpecimenMaxNumberOfHashesPer24HChanged(opts *bind.FilterOpts, chainId []uint64) (*ProofChainBlockSpecimenMaxNumberOfHashesPer24HChangedIterator, error) {
+
+	var chainIdRule []interface{}
+	for _, chainIdItem := range chainId {
+		chainIdRule = append(chainIdRule, chainIdItem)
+	}
+
+	logs, sub, err := _ProofChain.contract.FilterLogs(opts, "BlockSpecimenMaxNumberOfHashesPer24HChanged", chainIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ProofChainBlockSpecimenMaxNumberOfHashesPer24HChangedIterator{contract: _ProofChain.contract, event: "BlockSpecimenMaxNumberOfHashesPer24HChanged", logs: logs, sub: sub}, nil
 }
 
-// UpdateQuorumThreshold is a paid mutator transaction binding the contract method 0x6e8b4819.
+// WatchBlockSpecimenMaxNumberOfHashesPer24HChanged is a free log subscription operation binding the contract event 0xcd51a09527f1fdcb091e787cf5c06a462c010eaef61de7b7c3904916d95a4abd.
 //
-// Solidity: function updateQuorumThreshold(uint64 quorumThresholdNumerator) returns()
-func (_ProofChain *ProofChainTransactor) UpdateQuorumThreshold(opts *bind.TransactOpts, quorumThresholdNumerator uint64) (*types.Transaction, error) {
-	return _ProofChain.contract.Transact(opts, "updateQuorumThreshold", quorumThresholdNumerator)
+// Solidity: event BlockSpecimenMaxNumberOfHashesPer24HChanged(uint64 indexed chainId, uint64 newMaxNumberOfHashesPer24H)
+func (_ProofChain *ProofChainFilterer) WatchBlockSpecimenMaxNumberOfHashesPer24HChanged(opts *bind.WatchOpts, sink chan<- *ProofChainBlockSpecimenMaxNumberOfHashesPer24HChanged, chainId []uint64) (event.Subscription, error) {
+
+	var chainIdRule []interface{}
+	for _, chainIdItem := range chainId {
+		chainIdRule = append(chainIdRule, chainIdItem)
+	}
+
+	logs, sub, err := _ProofChain.contract.WatchLogs(opts, "BlockSpecimenMaxNumberOfHashesPer24HChanged", chainIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ProofChainBlockSpecimenMaxNumberOfHashesPer24HChanged)
+				if err := _ProofChain.contract.UnpackLog(event, "BlockSpecimenMaxNumberOfHashesPer24HChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
 }
 
-// UpdateQuorumThreshold is a paid mutator transaction binding the contract method 0x6e8b4819.
+// ParseBlockSpecimenMaxNumberOfHashesPer24HChanged is a log parse operation binding the contract event 0xcd51a09527f1fdcb091e787cf5c06a462c010eaef61de7b7c3904916d95a4abd.
 //
-// Solidity: function updateQuorumThreshold(uint64 quorumThresholdNumerator) returns()
-func (_ProofChain *ProofChainSession) UpdateQuorumThreshold(quorumThresholdNumerator uint64) (*types.Transaction, error) {
-	return _ProofChain.Contract.UpdateQuorumThreshold(&_ProofChain.TransactOpts, quorumThresholdNumerator)
+// Solidity: event BlockSpecimenMaxNumberOfHashesPer24HChanged(uint64 indexed chainId, uint64 newMaxNumberOfHashesPer24H)
+func (_ProofChain *ProofChainFilterer) ParseBlockSpecimenMaxNumberOfHashesPer24HChanged(log types.Log) (*ProofChainBlockSpecimenMaxNumberOfHashesPer24HChanged, error) {
+	event := new(ProofChainBlockSpecimenMaxNumberOfHashesPer24HChanged)
+	if err := _ProofChain.contract.UnpackLog(event, "BlockSpecimenMaxNumberOfHashesPer24HChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
 }
 
-// UpdateQuorumThreshold is a paid mutator transaction binding the contract method 0x6e8b4819.
+// ProofChainBlockSpecimenMinSubmissionRequiredChangedIterator is returned from FilterBlockSpecimenMinSubmissionRequiredChanged and is used to iterate over the raw logs and unpacked data for BlockSpecimenMinSubmissionRequiredChanged events raised by the ProofChain contract.
+type ProofChainBlockSpecimenMinSubmissionRequiredChangedIterator struct {
+	Event *ProofChainBlockSpecimenMinSubmissionRequiredChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ProofChainBlockSpecimenMinSubmissionRequiredChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ProofChainBlockSpecimenMinSubmissionRequiredChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ProofChainBlockSpecimenMinSubmissionRequiredChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ProofChainBlockSpecimenMinSubmissionRequiredChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ProofChainBlockSpecimenMinSubmissionRequiredChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ProofChainBlockSpecimenMinSubmissionRequiredChanged represents a BlockSpecimenMinSubmissionRequiredChanged event raised by the ProofChain contract.
+type ProofChainBlockSpecimenMinSubmissionRequiredChanged struct {
+	NewBlockSpecimenMinSubmissionsRequired *big.Int
+	Raw                                    types.Log // Blockchain specific contextual infos
+}
+
+// FilterBlockSpecimenMinSubmissionRequiredChanged is a free log retrieval operation binding the contract event 0xe2c2e6446883e57e5ecbdcf7b0a4e67007bcdb9191111ae6589d05a053ad8617.
 //
-// Solidity: function updateQuorumThreshold(uint64 quorumThresholdNumerator) returns()
-func (_ProofChain *ProofChainTransactorSession) UpdateQuorumThreshold(quorumThresholdNumerator uint64) (*types.Transaction, error) {
-	return _ProofChain.Contract.UpdateQuorumThreshold(&_ProofChain.TransactOpts, quorumThresholdNumerator)
+// Solidity: event BlockSpecimenMinSubmissionRequiredChanged(uint128 newBlockSpecimenMinSubmissionsRequired)
+func (_ProofChain *ProofChainFilterer) FilterBlockSpecimenMinSubmissionRequiredChanged(opts *bind.FilterOpts) (*ProofChainBlockSpecimenMinSubmissionRequiredChangedIterator, error) {
+
+	logs, sub, err := _ProofChain.contract.FilterLogs(opts, "BlockSpecimenMinSubmissionRequiredChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &ProofChainBlockSpecimenMinSubmissionRequiredChangedIterator{contract: _ProofChain.contract, event: "BlockSpecimenMinSubmissionRequiredChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchBlockSpecimenMinSubmissionRequiredChanged is a free log subscription operation binding the contract event 0xe2c2e6446883e57e5ecbdcf7b0a4e67007bcdb9191111ae6589d05a053ad8617.
+//
+// Solidity: event BlockSpecimenMinSubmissionRequiredChanged(uint128 newBlockSpecimenMinSubmissionsRequired)
+func (_ProofChain *ProofChainFilterer) WatchBlockSpecimenMinSubmissionRequiredChanged(opts *bind.WatchOpts, sink chan<- *ProofChainBlockSpecimenMinSubmissionRequiredChanged) (event.Subscription, error) {
+
+	logs, sub, err := _ProofChain.contract.WatchLogs(opts, "BlockSpecimenMinSubmissionRequiredChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ProofChainBlockSpecimenMinSubmissionRequiredChanged)
+				if err := _ProofChain.contract.UnpackLog(event, "BlockSpecimenMinSubmissionRequiredChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseBlockSpecimenMinSubmissionRequiredChanged is a log parse operation binding the contract event 0xe2c2e6446883e57e5ecbdcf7b0a4e67007bcdb9191111ae6589d05a053ad8617.
+//
+// Solidity: event BlockSpecimenMinSubmissionRequiredChanged(uint128 newBlockSpecimenMinSubmissionsRequired)
+func (_ProofChain *ProofChainFilterer) ParseBlockSpecimenMinSubmissionRequiredChanged(log types.Log) (*ProofChainBlockSpecimenMinSubmissionRequiredChanged, error) {
+	event := new(ProofChainBlockSpecimenMinSubmissionRequiredChanged)
+	if err := _ProofChain.contract.UnpackLog(event, "BlockSpecimenMinSubmissionRequiredChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
 }
 
 // ProofChainBlockSpecimenProductionProofSubmittedIterator is returned from FilterBlockSpecimenProductionProofSubmitted and is used to iterate over the raw logs and unpacked data for BlockSpecimenProductionProofSubmitted events raised by the ProofChain contract.
@@ -958,51 +1373,57 @@ func (it *ProofChainBlockSpecimenProductionProofSubmittedIterator) Close() error
 type ProofChainBlockSpecimenProductionProofSubmitted struct {
 	ChainId        uint64
 	BlockHeight    uint64
-	SpecimenSize   uint64
-	SpecimenLength uint64
+	BlockHash      [32]byte
 	SpecimenHash   [32]byte
 	StorageURL     string
+	SubmittedStake *big.Int
 	Raw            types.Log // Blockchain specific contextual infos
 }
 
-// FilterBlockSpecimenProductionProofSubmitted is a free log retrieval operation binding the contract event 0xd6167162e246a2d474fb881cb6dee451485884b64f01655f8f668ee415cbf9b2.
+// FilterBlockSpecimenProductionProofSubmitted is a free log retrieval operation binding the contract event 0x57b0cb34d2ff9ed661f8b3c684aaee6cbf0bda5da02f4044205556817fa8e76c.
 //
-// Solidity: event BlockSpecimenProductionProofSubmitted(uint64 chainId, uint64 indexed blockHeight, uint64 specimenSize, uint64 specimenLength, bytes32 indexed specimenHash, string storageURL)
-func (_ProofChain *ProofChainFilterer) FilterBlockSpecimenProductionProofSubmitted(opts *bind.FilterOpts, blockHeight []uint64, specimenHash [][32]byte) (*ProofChainBlockSpecimenProductionProofSubmittedIterator, error) {
+// Solidity: event BlockSpecimenProductionProofSubmitted(uint64 chainId, uint64 indexed blockHeight, bytes32 indexed blockHash, bytes32 indexed specimenHash, string storageURL, uint128 submittedStake)
+func (_ProofChain *ProofChainFilterer) FilterBlockSpecimenProductionProofSubmitted(opts *bind.FilterOpts, blockHeight []uint64, blockHash [][32]byte, specimenHash [][32]byte) (*ProofChainBlockSpecimenProductionProofSubmittedIterator, error) {
 
 	var blockHeightRule []interface{}
 	for _, blockHeightItem := range blockHeight {
 		blockHeightRule = append(blockHeightRule, blockHeightItem)
 	}
-
+	var blockHashRule []interface{}
+	for _, blockHashItem := range blockHash {
+		blockHashRule = append(blockHashRule, blockHashItem)
+	}
 	var specimenHashRule []interface{}
 	for _, specimenHashItem := range specimenHash {
 		specimenHashRule = append(specimenHashRule, specimenHashItem)
 	}
 
-	logs, sub, err := _ProofChain.contract.FilterLogs(opts, "BlockSpecimenProductionProofSubmitted", blockHeightRule, specimenHashRule)
+	logs, sub, err := _ProofChain.contract.FilterLogs(opts, "BlockSpecimenProductionProofSubmitted", blockHeightRule, blockHashRule, specimenHashRule)
 	if err != nil {
 		return nil, err
 	}
 	return &ProofChainBlockSpecimenProductionProofSubmittedIterator{contract: _ProofChain.contract, event: "BlockSpecimenProductionProofSubmitted", logs: logs, sub: sub}, nil
 }
 
-// WatchBlockSpecimenProductionProofSubmitted is a free log subscription operation binding the contract event 0xd6167162e246a2d474fb881cb6dee451485884b64f01655f8f668ee415cbf9b2.
+// WatchBlockSpecimenProductionProofSubmitted is a free log subscription operation binding the contract event 0x57b0cb34d2ff9ed661f8b3c684aaee6cbf0bda5da02f4044205556817fa8e76c.
 //
-// Solidity: event BlockSpecimenProductionProofSubmitted(uint64 chainId, uint64 indexed blockHeight, uint64 specimenSize, uint64 specimenLength, bytes32 indexed specimenHash, string storageURL)
-func (_ProofChain *ProofChainFilterer) WatchBlockSpecimenProductionProofSubmitted(opts *bind.WatchOpts, sink chan<- *ProofChainBlockSpecimenProductionProofSubmitted, blockHeight []uint64, specimenHash [][32]byte) (event.Subscription, error) {
+// Solidity: event BlockSpecimenProductionProofSubmitted(uint64 chainId, uint64 indexed blockHeight, bytes32 indexed blockHash, bytes32 indexed specimenHash, string storageURL, uint128 submittedStake)
+func (_ProofChain *ProofChainFilterer) WatchBlockSpecimenProductionProofSubmitted(opts *bind.WatchOpts, sink chan<- *ProofChainBlockSpecimenProductionProofSubmitted, blockHeight []uint64, blockHash [][32]byte, specimenHash [][32]byte) (event.Subscription, error) {
 
 	var blockHeightRule []interface{}
 	for _, blockHeightItem := range blockHeight {
 		blockHeightRule = append(blockHeightRule, blockHeightItem)
 	}
-
+	var blockHashRule []interface{}
+	for _, blockHashItem := range blockHash {
+		blockHashRule = append(blockHashRule, blockHashItem)
+	}
 	var specimenHashRule []interface{}
 	for _, specimenHashItem := range specimenHash {
 		specimenHashRule = append(specimenHashRule, specimenHashItem)
 	}
 
-	logs, sub, err := _ProofChain.contract.WatchLogs(opts, "BlockSpecimenProductionProofSubmitted", blockHeightRule, specimenHashRule)
+	logs, sub, err := _ProofChain.contract.WatchLogs(opts, "BlockSpecimenProductionProofSubmitted", blockHeightRule, blockHashRule, specimenHashRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1034,9 +1455,9 @@ func (_ProofChain *ProofChainFilterer) WatchBlockSpecimenProductionProofSubmitte
 	}), nil
 }
 
-// ParseBlockSpecimenProductionProofSubmitted is a log parse operation binding the contract event 0xd6167162e246a2d474fb881cb6dee451485884b64f01655f8f668ee415cbf9b2.
+// ParseBlockSpecimenProductionProofSubmitted is a log parse operation binding the contract event 0x57b0cb34d2ff9ed661f8b3c684aaee6cbf0bda5da02f4044205556817fa8e76c.
 //
-// Solidity: event BlockSpecimenProductionProofSubmitted(uint64 chainId, uint64 indexed blockHeight, uint64 specimenSize, uint64 specimenLength, bytes32 indexed specimenHash, string storageURL)
+// Solidity: event BlockSpecimenProductionProofSubmitted(uint64 chainId, uint64 indexed blockHeight, bytes32 indexed blockHash, bytes32 indexed specimenHash, string storageURL, uint128 submittedStake)
 func (_ProofChain *ProofChainFilterer) ParseBlockSpecimenProductionProofSubmitted(log types.Log) (*ProofChainBlockSpecimenProductionProofSubmitted, error) {
 	event := new(ProofChainBlockSpecimenProductionProofSubmitted)
 	if err := _ProofChain.contract.UnpackLog(event, "BlockSpecimenProductionProofSubmitted", log); err != nil {
@@ -1115,51 +1536,57 @@ func (it *ProofChainBlockSpecimenRewardAwardedIterator) Close() error {
 
 // ProofChainBlockSpecimenRewardAwarded represents a BlockSpecimenRewardAwarded event raised by the ProofChain contract.
 type ProofChainBlockSpecimenRewardAwarded struct {
-	ChainId         uint64
-	BlockHeight     uint64
-	Reward          *big.Int
-	OperatorAddress common.Address
-	Raw             types.Log // Blockchain specific contextual infos
+	ChainId      uint64
+	BlockHeight  uint64
+	Blockhash    [32]byte
+	Specimenhash [32]byte
+	Raw          types.Log // Blockchain specific contextual infos
 }
 
-// FilterBlockSpecimenRewardAwarded is a free log retrieval operation binding the contract event 0x105c3d60f0e35c6731e5828358dcbf158e40f122d68691c098931d2f57b661d1.
+// FilterBlockSpecimenRewardAwarded is a free log retrieval operation binding the contract event 0xf05ac779af1ec75a7b2fbe9415b33a67c00294a121786f7ce2eb3f92e4a6424a.
 //
-// Solidity: event BlockSpecimenRewardAwarded(uint64 chainId, uint64 indexed blockHeight, uint128 reward, address indexed operatorAddress)
-func (_ProofChain *ProofChainFilterer) FilterBlockSpecimenRewardAwarded(opts *bind.FilterOpts, blockHeight []uint64, operatorAddress []common.Address) (*ProofChainBlockSpecimenRewardAwardedIterator, error) {
+// Solidity: event BlockSpecimenRewardAwarded(uint64 indexed chainId, uint64 indexed blockHeight, bytes32 indexed blockhash, bytes32 specimenhash)
+func (_ProofChain *ProofChainFilterer) FilterBlockSpecimenRewardAwarded(opts *bind.FilterOpts, chainId []uint64, blockHeight []uint64, blockhash [][32]byte) (*ProofChainBlockSpecimenRewardAwardedIterator, error) {
 
+	var chainIdRule []interface{}
+	for _, chainIdItem := range chainId {
+		chainIdRule = append(chainIdRule, chainIdItem)
+	}
 	var blockHeightRule []interface{}
 	for _, blockHeightItem := range blockHeight {
 		blockHeightRule = append(blockHeightRule, blockHeightItem)
 	}
-
-	var operatorAddressRule []interface{}
-	for _, operatorAddressItem := range operatorAddress {
-		operatorAddressRule = append(operatorAddressRule, operatorAddressItem)
+	var blockhashRule []interface{}
+	for _, blockhashItem := range blockhash {
+		blockhashRule = append(blockhashRule, blockhashItem)
 	}
 
-	logs, sub, err := _ProofChain.contract.FilterLogs(opts, "BlockSpecimenRewardAwarded", blockHeightRule, operatorAddressRule)
+	logs, sub, err := _ProofChain.contract.FilterLogs(opts, "BlockSpecimenRewardAwarded", chainIdRule, blockHeightRule, blockhashRule)
 	if err != nil {
 		return nil, err
 	}
 	return &ProofChainBlockSpecimenRewardAwardedIterator{contract: _ProofChain.contract, event: "BlockSpecimenRewardAwarded", logs: logs, sub: sub}, nil
 }
 
-// WatchBlockSpecimenRewardAwarded is a free log subscription operation binding the contract event 0x105c3d60f0e35c6731e5828358dcbf158e40f122d68691c098931d2f57b661d1.
+// WatchBlockSpecimenRewardAwarded is a free log subscription operation binding the contract event 0xf05ac779af1ec75a7b2fbe9415b33a67c00294a121786f7ce2eb3f92e4a6424a.
 //
-// Solidity: event BlockSpecimenRewardAwarded(uint64 chainId, uint64 indexed blockHeight, uint128 reward, address indexed operatorAddress)
-func (_ProofChain *ProofChainFilterer) WatchBlockSpecimenRewardAwarded(opts *bind.WatchOpts, sink chan<- *ProofChainBlockSpecimenRewardAwarded, blockHeight []uint64, operatorAddress []common.Address) (event.Subscription, error) {
+// Solidity: event BlockSpecimenRewardAwarded(uint64 indexed chainId, uint64 indexed blockHeight, bytes32 indexed blockhash, bytes32 specimenhash)
+func (_ProofChain *ProofChainFilterer) WatchBlockSpecimenRewardAwarded(opts *bind.WatchOpts, sink chan<- *ProofChainBlockSpecimenRewardAwarded, chainId []uint64, blockHeight []uint64, blockhash [][32]byte) (event.Subscription, error) {
 
+	var chainIdRule []interface{}
+	for _, chainIdItem := range chainId {
+		chainIdRule = append(chainIdRule, chainIdItem)
+	}
 	var blockHeightRule []interface{}
 	for _, blockHeightItem := range blockHeight {
 		blockHeightRule = append(blockHeightRule, blockHeightItem)
 	}
-
-	var operatorAddressRule []interface{}
-	for _, operatorAddressItem := range operatorAddress {
-		operatorAddressRule = append(operatorAddressRule, operatorAddressItem)
+	var blockhashRule []interface{}
+	for _, blockhashItem := range blockhash {
+		blockhashRule = append(blockhashRule, blockhashItem)
 	}
 
-	logs, sub, err := _ProofChain.contract.WatchLogs(opts, "BlockSpecimenRewardAwarded", blockHeightRule, operatorAddressRule)
+	logs, sub, err := _ProofChain.contract.WatchLogs(opts, "BlockSpecimenRewardAwarded", chainIdRule, blockHeightRule, blockhashRule)
 	if err != nil {
 		return nil, err
 	}
@@ -1191,9 +1618,9 @@ func (_ProofChain *ProofChainFilterer) WatchBlockSpecimenRewardAwarded(opts *bin
 	}), nil
 }
 
-// ParseBlockSpecimenRewardAwarded is a log parse operation binding the contract event 0x105c3d60f0e35c6731e5828358dcbf158e40f122d68691c098931d2f57b661d1.
+// ParseBlockSpecimenRewardAwarded is a log parse operation binding the contract event 0xf05ac779af1ec75a7b2fbe9415b33a67c00294a121786f7ce2eb3f92e4a6424a.
 //
-// Solidity: event BlockSpecimenRewardAwarded(uint64 chainId, uint64 indexed blockHeight, uint128 reward, address indexed operatorAddress)
+// Solidity: event BlockSpecimenRewardAwarded(uint64 indexed chainId, uint64 indexed blockHeight, bytes32 indexed blockhash, bytes32 specimenhash)
 func (_ProofChain *ProofChainFilterer) ParseBlockSpecimenRewardAwarded(log types.Log) (*ProofChainBlockSpecimenRewardAwarded, error) {
 	event := new(ProofChainBlockSpecimenRewardAwarded)
 	if err := _ProofChain.contract.UnpackLog(event, "BlockSpecimenRewardAwarded", log); err != nil {
@@ -1484,6 +1911,285 @@ func (_ProofChain *ProofChainFilterer) WatchBlockSpecimenSessionFinalized(opts *
 func (_ProofChain *ProofChainFilterer) ParseBlockSpecimenSessionFinalized(log types.Log) (*ProofChainBlockSpecimenSessionFinalized, error) {
 	event := new(ProofChainBlockSpecimenSessionFinalized)
 	if err := _ProofChain.contract.UnpackLog(event, "BlockSpecimenSessionFinalized", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ProofChainMinimumRequiredStakeChangedIterator is returned from FilterMinimumRequiredStakeChanged and is used to iterate over the raw logs and unpacked data for MinimumRequiredStakeChanged events raised by the ProofChain contract.
+type ProofChainMinimumRequiredStakeChangedIterator struct {
+	Event *ProofChainMinimumRequiredStakeChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ProofChainMinimumRequiredStakeChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ProofChainMinimumRequiredStakeChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ProofChainMinimumRequiredStakeChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ProofChainMinimumRequiredStakeChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ProofChainMinimumRequiredStakeChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ProofChainMinimumRequiredStakeChanged represents a MinimumRequiredStakeChanged event raised by the ProofChain contract.
+type ProofChainMinimumRequiredStakeChanged struct {
+	Role                [32]byte
+	NewStakeRequirement *big.Int
+	Raw                 types.Log // Blockchain specific contextual infos
+}
+
+// FilterMinimumRequiredStakeChanged is a free log retrieval operation binding the contract event 0xcc5adc82271e3da3beed19bdd358519f24712369aa0cd14ec87e36a0eaa8efaa.
+//
+// Solidity: event MinimumRequiredStakeChanged(bytes32 indexed role, uint128 newStakeRequirement)
+func (_ProofChain *ProofChainFilterer) FilterMinimumRequiredStakeChanged(opts *bind.FilterOpts, role [][32]byte) (*ProofChainMinimumRequiredStakeChangedIterator, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+
+	logs, sub, err := _ProofChain.contract.FilterLogs(opts, "MinimumRequiredStakeChanged", roleRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ProofChainMinimumRequiredStakeChangedIterator{contract: _ProofChain.contract, event: "MinimumRequiredStakeChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchMinimumRequiredStakeChanged is a free log subscription operation binding the contract event 0xcc5adc82271e3da3beed19bdd358519f24712369aa0cd14ec87e36a0eaa8efaa.
+//
+// Solidity: event MinimumRequiredStakeChanged(bytes32 indexed role, uint128 newStakeRequirement)
+func (_ProofChain *ProofChainFilterer) WatchMinimumRequiredStakeChanged(opts *bind.WatchOpts, sink chan<- *ProofChainMinimumRequiredStakeChanged, role [][32]byte) (event.Subscription, error) {
+
+	var roleRule []interface{}
+	for _, roleItem := range role {
+		roleRule = append(roleRule, roleItem)
+	}
+
+	logs, sub, err := _ProofChain.contract.WatchLogs(opts, "MinimumRequiredStakeChanged", roleRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ProofChainMinimumRequiredStakeChanged)
+				if err := _ProofChain.contract.UnpackLog(event, "MinimumRequiredStakeChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseMinimumRequiredStakeChanged is a log parse operation binding the contract event 0xcc5adc82271e3da3beed19bdd358519f24712369aa0cd14ec87e36a0eaa8efaa.
+//
+// Solidity: event MinimumRequiredStakeChanged(bytes32 indexed role, uint128 newStakeRequirement)
+func (_ProofChain *ProofChainFilterer) ParseMinimumRequiredStakeChanged(log types.Log) (*ProofChainMinimumRequiredStakeChanged, error) {
+	event := new(ProofChainMinimumRequiredStakeChanged)
+	if err := _ProofChain.contract.UnpackLog(event, "MinimumRequiredStakeChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ProofChainNumberOfBlocksPer24HChangedIterator is returned from FilterNumberOfBlocksPer24HChanged and is used to iterate over the raw logs and unpacked data for NumberOfBlocksPer24HChanged events raised by the ProofChain contract.
+type ProofChainNumberOfBlocksPer24HChangedIterator struct {
+	Event *ProofChainNumberOfBlocksPer24HChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ProofChainNumberOfBlocksPer24HChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ProofChainNumberOfBlocksPer24HChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ProofChainNumberOfBlocksPer24HChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ProofChainNumberOfBlocksPer24HChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ProofChainNumberOfBlocksPer24HChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ProofChainNumberOfBlocksPer24HChanged represents a NumberOfBlocksPer24HChanged event raised by the ProofChain contract.
+type ProofChainNumberOfBlocksPer24HChanged struct {
+	NumberOfBlocks uint64
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterNumberOfBlocksPer24HChanged is a free log retrieval operation binding the contract event 0xd110b97bc9e6210ae4a53402f5a2835c92dbe790fc6b679468af199a13756d98.
+//
+// Solidity: event NumberOfBlocksPer24HChanged(uint64 numberOfBlocks)
+func (_ProofChain *ProofChainFilterer) FilterNumberOfBlocksPer24HChanged(opts *bind.FilterOpts) (*ProofChainNumberOfBlocksPer24HChangedIterator, error) {
+
+	logs, sub, err := _ProofChain.contract.FilterLogs(opts, "NumberOfBlocksPer24HChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &ProofChainNumberOfBlocksPer24HChangedIterator{contract: _ProofChain.contract, event: "NumberOfBlocksPer24HChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchNumberOfBlocksPer24HChanged is a free log subscription operation binding the contract event 0xd110b97bc9e6210ae4a53402f5a2835c92dbe790fc6b679468af199a13756d98.
+//
+// Solidity: event NumberOfBlocksPer24HChanged(uint64 numberOfBlocks)
+func (_ProofChain *ProofChainFilterer) WatchNumberOfBlocksPer24HChanged(opts *bind.WatchOpts, sink chan<- *ProofChainNumberOfBlocksPer24HChanged) (event.Subscription, error) {
+
+	logs, sub, err := _ProofChain.contract.WatchLogs(opts, "NumberOfBlocksPer24HChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ProofChainNumberOfBlocksPer24HChanged)
+				if err := _ProofChain.contract.UnpackLog(event, "NumberOfBlocksPer24HChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseNumberOfBlocksPer24HChanged is a log parse operation binding the contract event 0xd110b97bc9e6210ae4a53402f5a2835c92dbe790fc6b679468af199a13756d98.
+//
+// Solidity: event NumberOfBlocksPer24HChanged(uint64 numberOfBlocks)
+func (_ProofChain *ProofChainFilterer) ParseNumberOfBlocksPer24HChanged(log types.Log) (*ProofChainNumberOfBlocksPer24HChanged, error) {
+	event := new(ProofChainNumberOfBlocksPer24HChanged)
+	if err := _ProofChain.contract.UnpackLog(event, "NumberOfBlocksPer24HChanged", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
@@ -1808,6 +2514,151 @@ func (_ProofChain *ProofChainFilterer) WatchOperatorStoppedRole(opts *bind.Watch
 func (_ProofChain *ProofChainFilterer) ParseOperatorStoppedRole(log types.Log) (*ProofChainOperatorStoppedRole, error) {
 	event := new(ProofChainOperatorStoppedRole)
 	if err := _ProofChain.contract.UnpackLog(event, "OperatorStoppedRole", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ProofChainQuorumNotReachedIterator is returned from FilterQuorumNotReached and is used to iterate over the raw logs and unpacked data for QuorumNotReached events raised by the ProofChain contract.
+type ProofChainQuorumNotReachedIterator struct {
+	Event *ProofChainQuorumNotReached // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ProofChainQuorumNotReachedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ProofChainQuorumNotReached)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ProofChainQuorumNotReached)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ProofChainQuorumNotReachedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ProofChainQuorumNotReachedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ProofChainQuorumNotReached represents a QuorumNotReached event raised by the ProofChain contract.
+type ProofChainQuorumNotReached struct {
+	ChainId     uint64
+	BlockHeight uint64
+	Raw         types.Log // Blockchain specific contextual infos
+}
+
+// FilterQuorumNotReached is a free log retrieval operation binding the contract event 0x398fd8f638a7242217f011fd0720a06747f7a85b7d28d7276684b841baea4021.
+//
+// Solidity: event QuorumNotReached(uint64 indexed chainId, uint64 blockHeight)
+func (_ProofChain *ProofChainFilterer) FilterQuorumNotReached(opts *bind.FilterOpts, chainId []uint64) (*ProofChainQuorumNotReachedIterator, error) {
+
+	var chainIdRule []interface{}
+	for _, chainIdItem := range chainId {
+		chainIdRule = append(chainIdRule, chainIdItem)
+	}
+
+	logs, sub, err := _ProofChain.contract.FilterLogs(opts, "QuorumNotReached", chainIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return &ProofChainQuorumNotReachedIterator{contract: _ProofChain.contract, event: "QuorumNotReached", logs: logs, sub: sub}, nil
+}
+
+// WatchQuorumNotReached is a free log subscription operation binding the contract event 0x398fd8f638a7242217f011fd0720a06747f7a85b7d28d7276684b841baea4021.
+//
+// Solidity: event QuorumNotReached(uint64 indexed chainId, uint64 blockHeight)
+func (_ProofChain *ProofChainFilterer) WatchQuorumNotReached(opts *bind.WatchOpts, sink chan<- *ProofChainQuorumNotReached, chainId []uint64) (event.Subscription, error) {
+
+	var chainIdRule []interface{}
+	for _, chainIdItem := range chainId {
+		chainIdRule = append(chainIdRule, chainIdItem)
+	}
+
+	logs, sub, err := _ProofChain.contract.WatchLogs(opts, "QuorumNotReached", chainIdRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ProofChainQuorumNotReached)
+				if err := _ProofChain.contract.UnpackLog(event, "QuorumNotReached", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseQuorumNotReached is a log parse operation binding the contract event 0x398fd8f638a7242217f011fd0720a06747f7a85b7d28d7276684b841baea4021.
+//
+// Solidity: event QuorumNotReached(uint64 indexed chainId, uint64 blockHeight)
+func (_ProofChain *ProofChainFilterer) ParseQuorumNotReached(log types.Log) (*ProofChainQuorumNotReached, error) {
+	event := new(ProofChainQuorumNotReached)
+	if err := _ProofChain.contract.UnpackLog(event, "QuorumNotReached", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log
@@ -2434,6 +3285,140 @@ func (_ProofChain *ProofChainFilterer) ParseSpecimenSessionDurationChanged(log t
 	return event, nil
 }
 
+// ProofChainSpecimenSessionMinSubmissionChangedIterator is returned from FilterSpecimenSessionMinSubmissionChanged and is used to iterate over the raw logs and unpacked data for SpecimenSessionMinSubmissionChanged events raised by the ProofChain contract.
+type ProofChainSpecimenSessionMinSubmissionChangedIterator struct {
+	Event *ProofChainSpecimenSessionMinSubmissionChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ProofChainSpecimenSessionMinSubmissionChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ProofChainSpecimenSessionMinSubmissionChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ProofChainSpecimenSessionMinSubmissionChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ProofChainSpecimenSessionMinSubmissionChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ProofChainSpecimenSessionMinSubmissionChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ProofChainSpecimenSessionMinSubmissionChanged represents a SpecimenSessionMinSubmissionChanged event raised by the ProofChain contract.
+type ProofChainSpecimenSessionMinSubmissionChanged struct {
+	MinSubmissions uint64
+	Raw            types.Log // Blockchain specific contextual infos
+}
+
+// FilterSpecimenSessionMinSubmissionChanged is a free log retrieval operation binding the contract event 0x28312bbddd51eea4439db773218c441a4057f6ed285c642a569f1dcdba1cc047.
+//
+// Solidity: event SpecimenSessionMinSubmissionChanged(uint64 minSubmissions)
+func (_ProofChain *ProofChainFilterer) FilterSpecimenSessionMinSubmissionChanged(opts *bind.FilterOpts) (*ProofChainSpecimenSessionMinSubmissionChangedIterator, error) {
+
+	logs, sub, err := _ProofChain.contract.FilterLogs(opts, "SpecimenSessionMinSubmissionChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &ProofChainSpecimenSessionMinSubmissionChangedIterator{contract: _ProofChain.contract, event: "SpecimenSessionMinSubmissionChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchSpecimenSessionMinSubmissionChanged is a free log subscription operation binding the contract event 0x28312bbddd51eea4439db773218c441a4057f6ed285c642a569f1dcdba1cc047.
+//
+// Solidity: event SpecimenSessionMinSubmissionChanged(uint64 minSubmissions)
+func (_ProofChain *ProofChainFilterer) WatchSpecimenSessionMinSubmissionChanged(opts *bind.WatchOpts, sink chan<- *ProofChainSpecimenSessionMinSubmissionChanged) (event.Subscription, error) {
+
+	logs, sub, err := _ProofChain.contract.WatchLogs(opts, "SpecimenSessionMinSubmissionChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ProofChainSpecimenSessionMinSubmissionChanged)
+				if err := _ProofChain.contract.UnpackLog(event, "SpecimenSessionMinSubmissionChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseSpecimenSessionMinSubmissionChanged is a log parse operation binding the contract event 0x28312bbddd51eea4439db773218c441a4057f6ed285c642a569f1dcdba1cc047.
+//
+// Solidity: event SpecimenSessionMinSubmissionChanged(uint64 minSubmissions)
+func (_ProofChain *ProofChainFilterer) ParseSpecimenSessionMinSubmissionChanged(log types.Log) (*ProofChainSpecimenSessionMinSubmissionChanged, error) {
+	event := new(ProofChainSpecimenSessionMinSubmissionChanged)
+	if err := _ProofChain.contract.UnpackLog(event, "SpecimenSessionMinSubmissionChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
 // ProofChainSpecimenSessionQuorumChangedIterator is returned from FilterSpecimenSessionQuorumChanged and is used to iterate over the raw logs and unpacked data for SpecimenSessionQuorumChanged events raised by the ProofChain contract.
 type ProofChainSpecimenSessionQuorumChangedIterator struct {
 	Event *ProofChainSpecimenSessionQuorumChanged // Event containing the contract specifics and raw log
@@ -2562,6 +3547,140 @@ func (_ProofChain *ProofChainFilterer) WatchSpecimenSessionQuorumChanged(opts *b
 func (_ProofChain *ProofChainFilterer) ParseSpecimenSessionQuorumChanged(log types.Log) (*ProofChainSpecimenSessionQuorumChanged, error) {
 	event := new(ProofChainSpecimenSessionQuorumChanged)
 	if err := _ProofChain.contract.UnpackLog(event, "SpecimenSessionQuorumChanged", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// ProofChainStakingInterfaceChangedIterator is returned from FilterStakingInterfaceChanged and is used to iterate over the raw logs and unpacked data for StakingInterfaceChanged events raised by the ProofChain contract.
+type ProofChainStakingInterfaceChangedIterator struct {
+	Event *ProofChainStakingInterfaceChanged // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *ProofChainStakingInterfaceChangedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(ProofChainStakingInterfaceChanged)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(ProofChainStakingInterfaceChanged)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *ProofChainStakingInterfaceChangedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *ProofChainStakingInterfaceChangedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// ProofChainStakingInterfaceChanged represents a StakingInterfaceChanged event raised by the ProofChain contract.
+type ProofChainStakingInterfaceChanged struct {
+	NewInterfaceAddress common.Address
+	Raw                 types.Log // Blockchain specific contextual infos
+}
+
+// FilterStakingInterfaceChanged is a free log retrieval operation binding the contract event 0x70016f37fc9a299f674d1e3083a27743406649810887ed947a79884b064d2de9.
+//
+// Solidity: event StakingInterfaceChanged(address newInterfaceAddress)
+func (_ProofChain *ProofChainFilterer) FilterStakingInterfaceChanged(opts *bind.FilterOpts) (*ProofChainStakingInterfaceChangedIterator, error) {
+
+	logs, sub, err := _ProofChain.contract.FilterLogs(opts, "StakingInterfaceChanged")
+	if err != nil {
+		return nil, err
+	}
+	return &ProofChainStakingInterfaceChangedIterator{contract: _ProofChain.contract, event: "StakingInterfaceChanged", logs: logs, sub: sub}, nil
+}
+
+// WatchStakingInterfaceChanged is a free log subscription operation binding the contract event 0x70016f37fc9a299f674d1e3083a27743406649810887ed947a79884b064d2de9.
+//
+// Solidity: event StakingInterfaceChanged(address newInterfaceAddress)
+func (_ProofChain *ProofChainFilterer) WatchStakingInterfaceChanged(opts *bind.WatchOpts, sink chan<- *ProofChainStakingInterfaceChanged) (event.Subscription, error) {
+
+	logs, sub, err := _ProofChain.contract.WatchLogs(opts, "StakingInterfaceChanged")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(ProofChainStakingInterfaceChanged)
+				if err := _ProofChain.contract.UnpackLog(event, "StakingInterfaceChanged", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseStakingInterfaceChanged is a log parse operation binding the contract event 0x70016f37fc9a299f674d1e3083a27743406649810887ed947a79884b064d2de9.
+//
+// Solidity: event StakingInterfaceChanged(address newInterfaceAddress)
+func (_ProofChain *ProofChainFilterer) ParseStakingInterfaceChanged(log types.Log) (*ProofChainStakingInterfaceChanged, error) {
+	event := new(ProofChainStakingInterfaceChanged)
+	if err := _ProofChain.contract.UnpackLog(event, "StakingInterfaceChanged", log); err != nil {
 		return nil, err
 	}
 	event.Raw = log

--- a/internal/websocket/websocket.go
+++ b/internal/websocket/websocket.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/linkedin/goavro/v2"
 	log "github.com/sirupsen/logrus"
-	"github.com/ubiq/go-ubiq/common"
 )
 
 // ConsumeWebsocketsEvents is the primary consumer of websocket events from an websocket endpoint
@@ -85,7 +84,7 @@ func ConsumeWebsocketsEvents(config *config.EthConfig, websocketURL string, repl
 			} else {
 				replicaURL = "only local ./bin/"
 			}
-			go proof.SendBlockReplicaProofTx(ctx, config, proofChain, ethClient, uint64(res.Block.Nonce), 1, message, replicaURL, common.Hash{}, proofTxHash)
+			go proof.SendBlockReplicaProofTx(ctx, config, proofChain, ethClient, uint64(res.Block.Nonce), 1, message, replicaURL, &types.BlockReplica{}, proofTxHash)
 			pTxHash := <-proofTxHash
 			if pTxHash != "" {
 				log.Info("Proof-chain tx hash: ", pTxHash, " for block-replica segment: ", segmentName)

--- a/internal/websocket/websocket.go
+++ b/internal/websocket/websocket.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/linkedin/goavro/v2"
 	log "github.com/sirupsen/logrus"
+	"github.com/ubiq/go-ubiq/common"
 )
 
 // ConsumeWebsocketsEvents is the primary consumer of websocket events from an websocket endpoint
@@ -84,7 +85,7 @@ func ConsumeWebsocketsEvents(config *config.EthConfig, websocketURL string, repl
 			} else {
 				replicaURL = "only local ./bin/"
 			}
-			go proof.SendBlockReplicaProofTx(ctx, config, proofChain, ethClient, uint64(res.Block.Nonce), 1, message, replicaURL, proofTxHash)
+			go proof.SendBlockReplicaProofTx(ctx, config, proofChain, ethClient, uint64(res.Block.Nonce), 1, message, replicaURL, common.Hash{}, proofTxHash)
 			pTxHash := <-proofTxHash
 			if pTxHash != "" {
 				log.Info("Proof-chain tx hash: ", pTxHash, " for block-replica segment: ", segmentName)


### PR DESCRIPTION
* Updated ABI bindings to the latest on `main` [op-stake](https://github.com/covalenthq/operational-staking/commit/fb392c5e08bae821f144521cd4b51014b72ba844)
* Addition of origin chain blockHash (object hash) to submitBlockSpecimenProof
* Restructure naming of single replica segments
* Correction of proof submission of EVM source `chainId` and not eth client `chainId` to proof-chain

Signed-off-by: Pranay Valson <pranay.valson@gmail.com>