### PR TITLE
Update to CI (docker) integration test

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -72,13 +72,16 @@ jobs:
         docker build . --file Dockerfile --tag ghcr.io/covalenthq/bsp-agent:latest
         docker push ghcr.io/covalenthq/bsp-agent:latest
 
-    - name: Create .envrc file
+    - name: Create .env file
       run: |
-        touch .envrc
-        echo PRIVATE_KEY=${{ secrets.PRIVATE_KEY }} >> .envrc
-        echo RPC_URL=${{ secrets.RPC_URL }} >> .envrc
+        touch .env
+        echo PRIVATE_KEY=${{ secrets.PRIVATE_KEY }} >> .env
+        echo RPC_URL=${{ secrets.RPC_URL }} >> .env
+        cat .env
 
-    - uses: HatsuneMiku3939/direnv-action@v1
+    - name: Load .env file
+      uses: xom9ikk/dotenv@v1.0.2
+
     - name: Start containers
       run: docker-compose -f "docker-compose-ci.yml" up --build --remove-orphans --exit-code-from agent
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,14 +25,15 @@ jobs:
         docker build . --file Dockerfile --tag ghcr.io/covalenthq/bsp-agent:latest
         docker push ghcr.io/covalenthq/bsp-agent:latest
 
-    - name: Create .envrc file
+    - name: Create .env file
       run: |
-        touch .envrc
-        echo PRIVATE_KEY=${{ secrets.PRIVATE_KEY }} >> .envrc
-        echo RPC_URL=${{ secrets.RPC_URL }} >> .envrc
+        touch .env
+        echo PRIVATE_KEY=${{ secrets.PRIVATE_KEY }} >> .env
+        echo RPC_URL=${{ secrets.RPC_URL }} >> .env
+        cat .env
 
-    - name: Load Env
-      uses: HatsuneMiku3939/direnv-action@v1
+    - name: Load .env file
+      uses: xom9ikk/dotenv@v1.0.2
 
     - name: Run Containers
       run: docker-compose -f "docker-compose-ci.yml" up --build --remove-orphans --exit-code-from agent

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,8 +31,10 @@ jobs:
         echo PRIVATE_KEY=${{ secrets.PRIVATE_KEY }} >> .envrc
         echo RPC_URL=${{ secrets.RPC_URL }} >> .envrc
 
-    - uses: HatsuneMiku3939/direnv-action@v1
-    - name: Start containers
+    - name: Load Env
+      uses: HatsuneMiku3939/direnv-action@v1
+
+    - name: Run Containers
       run: docker-compose -f "docker-compose-ci.yml" up --build --remove-orphans --exit-code-from agent
 
     - name: Check running agent

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,16 +13,23 @@ permissions:
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
   # pull-requests: read
 jobs:
-  golangci:
-    name: go-lint
+  golangci-build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v3
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.44
+          go-version: 1.17.2
+        id: go
+      - run: go version
+
+      - name: Lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.44.0
+          ./bin/golangci-lint run
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.43
+          version: v1.44
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -95,7 +95,7 @@ services:
         sleep 1;
         done;
         echo proof-chain contracts deployed!;
-        ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication#replicate  --avro-codec-path=./codec/block-ethereum.avsc --binary-file-path=./bin/block-ethereum/ --gcp-svc-account=./gcloud/bsp-2.json --replica-bucket=covalenthq-geth-block-specimen --segment-length=10 --proof-chain-address=0xEa2ff902dbeEECcc828757B881b343F9316752e5 --consumer-timeout=15;
+        ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication#replicate  --avro-codec-path=./codec/block-ethereum.avsc --binary-file-path=./bin/block-ethereum/ --gcp-svc-account=./gcloud/bsp-2.json --replica-bucket=covalenthq-geth-block-specimen --segment-length=1 --proof-chain-address=0xEa2ff902dbeEECcc828757B881b343F9316752e5 --consumer-timeout=15;
         exit 0;"
     environment:
       - ETH_PRIVATE_KEY=${PRIVATE_KEY}

--- a/entry.sh
+++ b/entry.sh
@@ -5,7 +5,7 @@ then
     --avro-codec-path=./codec/block-elrond.avsc \
     --binary-file-path=./bin/block-elrond/ \
     --segment-length=1 \
-    --proof-chain-address=0x6fbe1051956b1b2416c49e5e5076588fd4f072a1\
+    --proof-chain-address=0xea2ff902dbeeeccc828757b881b343f9316752e5\
     --consumer-timeout=15 \
     --websocket-urls="34.66.210.112:20000 34.66.210.112:20001 34.66.210.112:20002 34.66.210.112:20003" 
 else
@@ -13,6 +13,6 @@ else
     --avro-codec-path=./codec/block-ethereum.avsc \
     --binary-file-path=./bin/block-ethereum/ \
     --segment-length=1 \
-    --proof-chain-address=0x6fbe1051956b1b2416c49e5e5076588fd4f072a1 \
+    --proof-chain-address=0xea2ff902dbeeeccc828757b881b343f9316752e5 \
     --consumer-timeout=15
 fi

--- a/entry.sh
+++ b/entry.sh
@@ -5,7 +5,7 @@ then
     --avro-codec-path=./codec/block-elrond.avsc \
     --binary-file-path=./bin/block-elrond/ \
     --segment-length=1 \
-    --proof-chain-address=0xea2ff902dbeeeccc828757b881b343f9316752e5 \
+    --proof-chain-address=0x6fbe1051956b1b2416c49e5e5076588fd4f072a1\
     --consumer-timeout=15 \
     --websocket-urls="34.66.210.112:20000 34.66.210.112:20001 34.66.210.112:20002 34.66.210.112:20003" 
 else
@@ -13,6 +13,6 @@ else
     --avro-codec-path=./codec/block-ethereum.avsc \
     --binary-file-path=./bin/block-ethereum/ \
     --segment-length=1 \
-    --proof-chain-address=0xea2ff902dbeeeccc828757b881b343f9316752e5 \
+    --proof-chain-address=0x6fbe1051956b1b2416c49e5e5076588fd4f072a1 \
     --consumer-timeout=15
 fi

--- a/entry.sh
+++ b/entry.sh
@@ -5,7 +5,7 @@ then
     --avro-codec-path=./codec/block-elrond.avsc \
     --binary-file-path=./bin/block-elrond/ \
     --segment-length=10 \
-    --proof-chain-address=0xEa2ff902dbeEECcc828757B881b343F9316752e5 \
+    --proof-chain-address=0xea2ff902dbeeeccc828757b881b343f9316752e5 \
     --consumer-timeout=15 \
     --websocket-urls="34.66.210.112:20000 34.66.210.112:20001 34.66.210.112:20002 34.66.210.112:20003" 
 else
@@ -13,6 +13,6 @@ else
     --avro-codec-path=./codec/block-ethereum.avsc \
     --binary-file-path=./bin/block-ethereum/ \
     --segment-length=10 \
-    --proof-chain-address=0xEa2ff902dbeEECcc828757B881b343F9316752e5 \
+    --proof-chain-address=0xea2ff902dbeeeccc828757b881b343f9316752e5 \
     --consumer-timeout=15
 fi

--- a/entry.sh
+++ b/entry.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [ "$BLOCKCHAIN" == "elrond" ]
 then
-    timeout 120s ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication#replicate \
+    timeout 120s ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication-1#replicate \
     --avro-codec-path=./codec/block-elrond.avsc \
     --binary-file-path=./bin/block-elrond/ \
     --segment-length=10 \
@@ -9,7 +9,7 @@ then
     --consumer-timeout=15 \
     --websocket-urls="34.66.210.112:20000 34.66.210.112:20001 34.66.210.112:20002 34.66.210.112:20003" 
 else
-    ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication#replicate  \
+    ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication-1#replicate  \
     --avro-codec-path=./codec/block-ethereum.avsc \
     --binary-file-path=./bin/block-ethereum/ \
     --segment-length=10 \

--- a/entry.sh
+++ b/entry.sh
@@ -4,7 +4,7 @@ then
     timeout 120s ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication-1#replicate \
     --avro-codec-path=./codec/block-elrond.avsc \
     --binary-file-path=./bin/block-elrond/ \
-    --segment-length=10 \
+    --segment-length=1 \
     --proof-chain-address=0xea2ff902dbeeeccc828757b881b343f9316752e5 \
     --consumer-timeout=15 \
     --websocket-urls="34.66.210.112:20000 34.66.210.112:20001 34.66.210.112:20002 34.66.210.112:20003" 
@@ -12,7 +12,7 @@ else
     ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication-1#replicate  \
     --avro-codec-path=./codec/block-ethereum.avsc \
     --binary-file-path=./bin/block-ethereum/ \
-    --segment-length=10 \
+    --segment-length=1 \
     --proof-chain-address=0xea2ff902dbeeeccc828757b881b343f9316752e5 \
     --consumer-timeout=15
 fi


### PR DESCRIPTION
* fixes and replaces direnv with simple dotenv for hot env loading during CI end to end tests
* updates the proof-chain contract image necessary for docker-compose test
* updates the redis file dump to test against rinkeby block specimen RLP exports
* updates and pins correct version of `golangci-lint` for use by CI 
* improves overall CI testing workflow with predictability 

Signed-off-by: Pranay Valson <pranay.valson@gmail.com>