### PR TITLE
fix to ensure re-processing of non-ack'ed redis messages

### DIFF
--- a/cmd/bspagent/main.go
+++ b/cmd/bspagent/main.go
@@ -56,7 +56,7 @@ var (
 	logFolderFlag              = "./logs/"
 
 	// stream processing vars
-	start                 = ">"
+	start                 = "0"
 	streamKey             string
 	consumerGroup         string
 	replicaSegmentName    string


### PR DESCRIPTION
using 0 rather than '>' as stream start so that unacknowledged redis messages can be reprocessed.
- with '>' the readgroup calls moves the pointer ahead, despite ack not being done for that message
- with '0' the messages for which ack has not being sent, can be reprocessed by a newly spawned agent or existing one processing the pending messages.