### PR TITLE
update logger configuration to rotate every 24 hours

### DIFF
--- a/cmd/bspagent/main.go
+++ b/cmd/bspagent/main.go
@@ -17,6 +17,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	runtime "github.com/banzaicloud/logrus-runtime-formatter"
+	"github.com/covalenthq/lumberjack/v3"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/go-redis/redis/v7"
 	"github.com/golang/snappy"
@@ -26,7 +27,6 @@ import (
 	"github.com/ubiq/go-ubiq/rlp"
 	"golang.org/x/sys/unix"
 	"gopkg.in/avro.v0"
-	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/covalenthq/bsp-agent/internal/config"
 	"github.com/covalenthq/bsp-agent/internal/event"
@@ -98,10 +98,12 @@ func init() {
 		logFilePath := path.Join(logLocationURL.Path, "log.log")
 		bspLogger := utils.NewLoggerOut(os.Stdout, &lumberjack.Logger{
 			// logs folder created/searched in directory in which agent was started.
-			Filename:   logFilePath,
-			MaxSize:    100, // megabytes
-			MaxBackups: 7,
-			MaxAge:     10, // days
+			Filename:        logFilePath,
+			MaxSize:         100,          // for a log file (in megabytes)
+			MaxBackups:      10,           // maximum number of backup files to be created
+			MaxAge:          60,           // days
+			RollingInterval: 24 * 60 * 60, // 1 day (in seconds) -- one log file for each day
+			Compress:        true,         // gzip rolled over files
 		})
 		outWriter = &bspLogger
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/banzaicloud/logrus-runtime-formatter v0.0.0-20190729070250-5ae5475bae5e
 	github.com/btcsuite/btcd v0.20.1-beta // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.1.3 // indirect
+	github.com/covalenthq/lumberjack/v3 v3.0.1 // indirect
 	github.com/elodina/go-avro v0.0.0-20160406082632-0c8185d9a3ba
 	github.com/ethereum/go-ethereum v1.10.17
 	github.com/fatih/color v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,10 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/consensys/bavard v0.1.8-0.20210406032232-f3452dc9b572/go.mod h1:Bpd0/3mZuaj6Sj+PqrmIquiOKy397AKGThQPaGzNXAQ=
 github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f/go.mod h1:815PAHg3wvysy0SyIqanF8gZ0Y1wjk/hrDHD/iT88+Q=
+github.com/covalenthq/lumberjack/v3 v3.0.0 h1:g8Hi6mnk0OXi2NnQQK8RD6m9iYqb9EtzciPzQEDj8Ew=
+github.com/covalenthq/lumberjack/v3 v3.0.0/go.mod h1:zYPODax6DG1JWhLtebXGyZ2NciFZgQtEWajGLiJbrw0=
+github.com/covalenthq/lumberjack/v3 v3.0.1 h1:WDfNlLMTcMWiLaMEUcku9Jfcb5d8mOq4n5cIPA5l2Tg=
+github.com/covalenthq/lumberjack/v3 v3.0.1/go.mod h1:cpmebtW0NtC50USEqIlBtuoTZuxWIZGMT1cXfPKduII=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
@@ -164,6 +168,8 @@ github.com/deepmap/oapi-codegen v1.8.2/go.mod h1:YLgSKSDv/bZQB7N4ws6luhozi3cEdRk
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8/go.mod h1:VMaSuZ+SZcx/wljOQKvp5srsbCiKDEb6K2wC4+PiBmQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
+github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=


### PR DESCRIPTION
- update lumberjack go module to use the covalenthq fork (which has support for time-based log rotation) - https://github.com/covalenthq/lumberjack
- add configuration to rotate each day - this is to make it easier for operators (or us) to do some sort of analytics on the log for purpose of reward distribution/arbitration etc.