### PR TITLE
Fix operational constants and cli flag variables for live mode

### DIFF
--- a/cmd/bspagent/main.go
+++ b/cmd/bspagent/main.go
@@ -35,14 +35,17 @@ import (
 	pinner "github.com/covalenthq/ipfs-pinner"
 )
 
-var (
-	waitGrp sync.WaitGroup
-	// consts
+const (
 	consumerEvents            int64 = 1
 	consumerPendingIdleTime   int64 = 30
 	consumerPendingTimeTicker int64 = 120
 	// number of block specimen/results within a single uploaded avro encoded object
-	segmentLength = 1 // defaults to 1 block per segment in bsp-agent live mode
+	segmentLength int    = 1 // defaults to 1 block per segment in bsp-agent live mode
+	start         string = ">"
+)
+
+var (
+	waitGrp sync.WaitGroup
 
 	// env flag vars
 	blockDivisorFlag           int = 3  // can be set to any divisor (decrease specimen production throughput)
@@ -56,8 +59,8 @@ var (
 	websocketURLsFlag          string
 	ipfsServiceFlag            string
 	logFolderFlag              = "./logs/"
+
 	// stream processing vars
-	start                 = ">"
 	replicaSegmentName    string
 	replicaSegmentIDBatch []string
 	replicaSkipIDBatch    []string

--- a/cmd/bspagent/main.go
+++ b/cmd/bspagent/main.go
@@ -48,8 +48,8 @@ var (
 	waitGrp sync.WaitGroup
 
 	// env flag vars
-	blockDivisorFlag           int = 3  // can be set to any divisor (decrease specimen production throughput)
-	consumerPendingTimeoutFlag int = 60 // defaults to 1 min
+	blockDivisorFlag           = 3  // can be set to any divisor (decrease specimen production throughput)
+	consumerPendingTimeoutFlag = 60 // defaults to 1 min
 	avroCodecPathFlag          string
 	redisURLFlag               string
 	replicaBucketFlag          string

--- a/cmd/bspagent/main.go
+++ b/cmd/bspagent/main.go
@@ -38,14 +38,15 @@ import (
 var (
 	waitGrp sync.WaitGroup
 	// consts
-	consumerEvents            int64  = 1
-	consumerPendingIdleTime   int64  = 30
-	consumerPendingTimeTicker int64  = 120
-	blockNumberDivisor        uint64 = 3 // can be set to any divisor (decrease specimen production throughput)
+	consumerEvents            int64 = 1
+	consumerPendingIdleTime   int64 = 30
+	consumerPendingTimeTicker int64 = 120
+	// number of block specimen/results within a single uploaded avro encoded object
+	segmentLength = 1 // defaults to 1 block per segment in bsp-agent live mode
 
 	// env flag vars
-	consumerPendingTimeoutFlag = 60 // defaults to 1 min
-	segmentLengthFlag          = 1  // defaults to 1 block per segment
+	blockDivisorFlag           int = 3  // can be set to any divisor (decrease specimen production throughput)
+	consumerPendingTimeoutFlag int = 60 // defaults to 1 min
 	avroCodecPathFlag          string
 	redisURLFlag               string
 	replicaBucketFlag          string
@@ -53,8 +54,8 @@ var (
 	proofChainFlag             string
 	binaryFilePathFlag         string
 	websocketURLsFlag          string
+	ipfsServiceFlag            string
 	logFolderFlag              = "./logs/"
-	ipfsService                string
 	// stream processing vars
 	start                 = ">"
 	replicaSegmentName    string
@@ -72,10 +73,10 @@ func parseFlags() {
 	flag.StringVar(&replicaBucketFlag, "replica-bucket", utils.LookupEnvOrString("ReplicaBucket", replicaBucketFlag), "google cloud platform object store target for specimen")
 	flag.StringVar(&proofChainFlag, "proof-chain-address", utils.LookupEnvOrString("ProofChain", proofChainFlag), "hex string address for deployed proof-chain contract")
 	flag.StringVar(&websocketURLsFlag, "websocket-urls", utils.LookupEnvOrString("WebsocketURLs", websocketURLsFlag), "url to websockets clients separated by space")
-	flag.IntVar(&segmentLengthFlag, "segment-length", utils.LookupEnvOrInt("SegmentLength", segmentLengthFlag), "number of block specimen/results within a single uploaded avro encoded object")
+	flag.IntVar(&blockDivisorFlag, "block-divisor", utils.LookupEnvOrInt("BlockDivisor", blockDivisorFlag), "integer divisor that allows for selecting only block numbers divisible by this number")
 	flag.IntVar(&consumerPendingTimeoutFlag, "consumer-timeout", utils.LookupEnvOrInt("ConsumerPendingTimeout", consumerPendingTimeoutFlag), "number of seconds to wait before pending messages consumer timeout")
 	flag.StringVar(&logFolderFlag, "log-folder", utils.LookupEnvOrString("LogFolder", logFolderFlag), "Location where the log files should be placed")
-	flag.StringVar(&ipfsService, "ipfs-service", utils.LookupEnvOrString("IpfsService", ipfsService), "Allowed values are 'pinata' and 'others'")
+	flag.StringVar(&ipfsServiceFlag, "ipfs-service", utils.LookupEnvOrString("IpfsService", ipfsServiceFlag), "Allowed values are 'pinata' and 'others'")
 
 	flag.Parse()
 }
@@ -147,10 +148,10 @@ func main() {
 	}
 
 	var pinclient *pinner.Client
-	if ipfsService == pinner.Pinata.String() {
+	if ipfsServiceFlag == pinner.Pinata.String() {
 		req := pinner.NewClientRequest(pinner.Pinata).BearerToken(config.IPFSConfig.JWTToken)
 		pinclient = pinner.NewClient(req)
-	} else if ipfsService != "" {
+	} else if ipfsServiceFlag != "" {
 		log.Fatalf("Only pinata IPFS service supported for now")
 	}
 
@@ -295,16 +296,16 @@ func processStream(config *config.Config, replicaCodec *goavro.Codec, redisClien
 	switch {
 	case err != nil:
 		log.Error("error on process event: ", err)
-	case err == nil && objectReplica.Header.Number.Uint64()%blockNumberDivisor == 0:
+	case err == nil && objectReplica.Header.Number.Uint64()%uint64(blockDivisorFlag) == 0:
 		// collect stream ids and block replicas
 		replicaSegmentIDBatch = append(replicaSegmentIDBatch, stream.ID)
 		replicationSegment.BlockReplicaEvent = append(replicationSegment.BlockReplicaEvent, replica)
 		if len(replicationSegment.BlockReplicaEvent) == 1 {
 			replicationSegment.StartBlock = replica.Data.Header.Number.Uint64()
 		}
-		if len(replicationSegment.BlockReplicaEvent) == segmentLengthFlag {
+		if len(replicationSegment.BlockReplicaEvent) == segmentLength {
 			replicationSegment.EndBlock = replica.Data.Header.Number.Uint64()
-			replicationSegment.Elements = uint64(segmentLengthFlag)
+			replicationSegment.Elements = uint64(segmentLength)
 			replicaSegmentName = fmt.Sprint(replica.Data.NetworkId) + "-" + fmt.Sprint(replicationSegment.StartBlock) + objectType
 			// avro encode, prove and upload
 			_, err := handler.EncodeProveAndUploadReplicaSegment(ctx, &config.EthConfig, pinClient, replicaCodec, &replicationSegment, objectReplica, storageClient, ethClient, binaryFilePathFlag, replicaBucketFlag, replicaSegmentName, proofChainFlag)
@@ -313,7 +314,7 @@ func processStream(config *config.Config, replicaCodec *goavro.Codec, redisClien
 				panic(err)
 			}
 			// ack amd trim stream segment batch id
-			xlen, err := utils.AckTrimStreamSegment(config, redisClient, segmentLengthFlag, streamKey, consumerGroup, replicaSegmentIDBatch)
+			xlen, err := utils.AckTrimStreamSegment(config, redisClient, segmentLength, streamKey, consumerGroup, replicaSegmentIDBatch)
 			if err != nil {
 				log.Error("failed to match streamIDs length to segment length config: ", err)
 			}
@@ -326,9 +327,9 @@ func processStream(config *config.Config, replicaCodec *goavro.Codec, redisClien
 	default:
 		// collect block replicas and stream ids to skip
 		replicaSkipIDBatch = append(replicaSkipIDBatch, stream.ID)
-		log.Info("block-specimen not created for: ", objectReplica.Header.Number.Uint64(), ", base block number divisor is :", blockNumberDivisor)
+		log.Info("block-specimen not created for: ", objectReplica.Header.Number.Uint64(), ", base block number divisor is :", blockDivisorFlag)
 		// ack amd trim stream skip batch ids
-		xlen, err := utils.AckTrimStreamSegment(config, redisClient, segmentLengthFlag, streamKey, consumerGroup, replicaSkipIDBatch)
+		xlen, err := utils.AckTrimStreamSegment(config, redisClient, segmentLength, streamKey, consumerGroup, replicaSkipIDBatch)
 		if err != nil {
 			log.Error("failed to match streamIDs length to segment length config: ", err)
 			panic(err)

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -95,7 +95,7 @@ services:
         sleep 1;
         done;
         echo proof-chain contracts deployed!;
-        ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication#replicate  --avro-codec-path=./codec/block-ethereum.avsc --binary-file-path=./bin/block-ethereum/ --gcp-svc-account=./gcloud/bsp-2.json --replica-bucket=covalenthq-geth-block-specimen --segment-length=1 --proof-chain-address=0xEa2ff902dbeEECcc828757B881b343F9316752e5 --consumer-timeout=15;
+        ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication#replicate  --avro-codec-path=./codec/block-ethereum.avsc --binary-file-path=./bin/block-ethereum/ --gcp-svc-account=./gcloud/bsp-2.json --replica-bucket=covalenthq-geth-block-specimen --block-divisor=3 --proof-chain-address=0xEa2ff902dbeEECcc828757B881b343F9316752e5 --consumer-timeout=15;
         exit 0;"
     environment:
       - ETH_PRIVATE_KEY=${PRIVATE_KEY}

--- a/entry.sh
+++ b/entry.sh
@@ -4,7 +4,6 @@ then
     timeout 120s ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication-1#replicate \
     --avro-codec-path=./codec/block-elrond.avsc \
     --binary-file-path=./bin/block-elrond/ \
-    --segment-length=1 \
     --proof-chain-address=0xea2ff902dbeeeccc828757b881b343f9316752e5\
     --consumer-timeout=15 \
     --websocket-urls="34.66.210.112:20000 34.66.210.112:20001 34.66.210.112:20002 34.66.210.112:20003"
@@ -13,7 +12,7 @@ else
     ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication-1#replicate  \
     --avro-codec-path=./codec/block-ethereum.avsc \
     --binary-file-path=./bin/block-ethereum/ \
-    --segment-length=1 \
+    --block-divisor=3 \
     --proof-chain-address=0xea2ff902dbeeeccc828757b881b343f9316752e5 \
-    --consumer-timeout=15
+    --consumer-timeout=15 \
 fi

--- a/entry.sh
+++ b/entry.sh
@@ -14,5 +14,5 @@ else
     --binary-file-path=./bin/block-ethereum/ \
     --block-divisor=3 \
     --proof-chain-address=0xea2ff902dbeeeccc828757b881b343f9316752e5 \
-    --consumer-timeout=15 \
+    --consumer-timeout=15
 fi

--- a/internal/proof/proof.go
+++ b/internal/proof/proof.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
+const (
 	proofTxTimeout uint64 = 60
 )
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -17,7 +17,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var (
+const (
 	uploadTimeout int64 = 50
 )
 


### PR DESCRIPTION
* Moves base block-divisor const to variable flag (we can play with this for tx throughput on moonbeam)
* Moves specimen segment-length to const (since this is always 1 for bsp-agent live mode)
* Declares const(s) properly
* Tested end-to-end with new settings