### PR TITLE
Bug fix for proof-chain tx mine timeout and revert

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -88,6 +88,8 @@ func EncodeProveAndUploadReplicaSegment(ctx context.Context, config *config.EthC
 		return pTxHash, nil
 	case strings.Contains(pTxHash, "presubmitted hash"):
 		return pTxHash, nil
+	case strings.Contains(pTxHash, "mine timeout"):
+		return pTxHash, nil
 	case pTxHash == "":
 		return "", fmt.Errorf("failed to prove & upload block-replica segment event: %v", segmentName)
 	default:

--- a/internal/proof/proof.go
+++ b/internal/proof/proof.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	proofTxTimeout uint64 = 60
+	proofTxTimeout uint64 = 180
 )
 
 // SendBlockReplicaProofTx calls the proof-chain contract to make a transaction for the block-replica that it is processing

--- a/internal/proof/proof.go
+++ b/internal/proof/proof.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	proofTxTimeout uint64 = 300
+	proofTxTimeout uint64 = 301
 )
 
 // SendBlockReplicaProofTx calls the proof-chain contract to make a transaction for the block-replica that it is processing


### PR DESCRIPTION
* Increases the proof-chain tx timeout wait for mine for up to 301 seconds.
* Adds handler case for mine wait timeout but tx "success"
* Adds proof tx case for submitting proof tx revert, retry tx, recover and proceed
* Do not allow on fail-proof tx unless there is a major error in constructing the proof tx payload and queuing the tx in the mempool - by first executing an actual transaction invocation to the contract, deriving any missing authorization fields, signing the transaction, assembling the payload and injecting the signed tx into the pending pool for execution.