### PR TITLE
ipfs file cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	gopkg.in/avro.v0 v0.0.0-20171217001914-a730b5802183
 )
 
-require github.com/covalenthq/ipfs-pinner v0.1.5
+require github.com/covalenthq/ipfs-pinner v0.1.6
 
 require (
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 // indirect

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,12 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/covalenthq/ipfs-pinner v0.1.5 h1:JDp8aGRHkTsus2SMoJ0sTX8JFC4RG0YAZck34Yp6V0Q=
 github.com/covalenthq/ipfs-pinner v0.1.5/go.mod h1:vYR+kFOX5FHH/gezwG/C4p0LjFKZSUj/eO5eH5pV5Fw=
+github.com/covalenthq/ipfs-pinner v0.1.6-0.20220509210510-8f945da5c7d7 h1:WjfyR0+YoXcJuZ/E/w5R2H0LI8Z5+Cjagl3zmPY5rUU=
+github.com/covalenthq/ipfs-pinner v0.1.6-0.20220509210510-8f945da5c7d7/go.mod h1:vYR+kFOX5FHH/gezwG/C4p0LjFKZSUj/eO5eH5pV5Fw=
+github.com/covalenthq/ipfs-pinner v0.1.6-0.20220519125635-bedec4498b24 h1:QX5sSc/znka4o5KhGK3CURuaJVYyfVyOExy97wjCPlw=
+github.com/covalenthq/ipfs-pinner v0.1.6-0.20220519125635-bedec4498b24/go.mod h1:vYR+kFOX5FHH/gezwG/C4p0LjFKZSUj/eO5eH5pV5Fw=
+github.com/covalenthq/ipfs-pinner v0.1.6 h1:Z4mi5ZtS4CWEKHWAALsPxMPZm9rE33kGcbyy26qSm0U=
+github.com/covalenthq/ipfs-pinner v0.1.6/go.mod h1:vYR+kFOX5FHH/gezwG/C4p0LjFKZSUj/eO5eH5pV5Fw=
 github.com/covalenthq/lumberjack/v3 v3.0.1 h1:WDfNlLMTcMWiLaMEUcku9Jfcb5d8mOq4n5cIPA5l2Tg=
 github.com/covalenthq/lumberjack/v3 v3.0.1/go.mod h1:cpmebtW0NtC50USEqIlBtuoTZuxWIZGMT1cXfPKduII=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=


### PR DESCRIPTION
- cleans up temporary car files and .ipfs blocks after upload is done
- block replica binary files are still being persisted (locally) currently, and would account for most of the storage requirements of agent now.
