### PR TITLE
fix waitgrp race error

### DIFF
--- a/cmd/bspagent/main.go
+++ b/cmd/bspagent/main.go
@@ -80,7 +80,6 @@ func main() {
 }
 
 func setupMetrics() {
-	// address := fmt.Sprintf("%s:%d", ctx.GlobalString(MetricsHTTPFlag.Name), ctx.GlobalInt(MetricsPortFlag.Name))
 	if !agconfig.MetricsConfig.Enabled {
 		log.Info("metrics not enabled - skipping metrics setup...")
 

--- a/internal/metrics/exp/exp.go
+++ b/internal/metrics/exp/exp.go
@@ -60,6 +60,7 @@ func Setup(address string) {
 	m.Handle("/debug/metrics", ExpHandler(metrics.DefaultRegistry))
 	m.Handle("/debug/metrics/prometheus", prometheus.Handler(metrics.DefaultRegistry))
 	log.Info("Starting metrics server ", "addr: ", fmt.Sprintf("http://%s/debug/metrics", address))
+	log.Info("Exporting metrics in prometheus format at ", "addr: ", fmt.Sprintf("http://%s/debug/metrics/prometheus", address))
 	go func() {
 		if err := http.ListenAndServe(address, m); err != nil {
 			log.Error("Failure in running metrics server", "err", err)


### PR DESCRIPTION
- found "panic: sync: WaitGroup is reused before previous Wait has returned" in one of
  agent runs.
- it happens because of race conditions, when waiters are released (in `Wait`), but another
  `Add` happens at the same time.
- separating out into two waitgrps, so that the above pattern doesn't happen.
- There might still be case when during shutting down agent (via interrupt), the above pattern
  plays out, but that event is rarer.