### PR TITLE
Agent specimen binary extractor with files

### DIFF
--- a/scripts/extractor.go
+++ b/scripts/extractor.go
@@ -27,6 +27,7 @@ var (
 	indentJSONFlag     int
 )
 
+//nolint:unconvert
 func main() {
 	flag.StringVar(&binaryFilePathFlag, "binary-file-path", config.LookupEnvOrString("BinaryFilePath", binaryFilePathFlag), "local path to AVRO encoded binary files that contain block-replicas")
 	flag.StringVar(&avroCodecPathFlag, "codec-path", config.LookupEnvOrString("CodecPath", avroCodecPathFlag), "local path to AVRO .avsc files housing the specimen/result schemas")
@@ -66,19 +67,18 @@ func main() {
 			log.Error("unable to unmarshal decoded AVRO binary: ", err)
 		}
 
-		rawJson := json.RawMessage(string(decodedAvro))
+		rawJSON := json.RawMessage(string(decodedAvro))
 
-		indentJson, err := json.MarshalIndent(rawJson, "", "\t")
+		indentJSON, err := json.MarshalIndent(rawJSON, "", "\t")
 		if err != nil {
 			log.Error("unable to get indent raw json: ", err)
 		}
 
-		if err = ioutil.WriteFile(outputFilePathFlag+filename+"-specimen.json", indentJson, 0600); err != nil {
+		if err = ioutil.WriteFile(outputFilePathFlag+filename+"-specimen.json", indentJSON, 0600); err != nil {
 			log.Error("unable to write to file: ", err)
 		}
 
 		fmt.Println("\nfile: ", filepath.Join(outputFilePathFlag, filepath.Base(filename+"-specimen.json")), "bytes: ", size)
-
 	}
 }
 

--- a/scripts/extractor.go
+++ b/scripts/extractor.go
@@ -68,12 +68,12 @@ func main() {
 
 		rawJson := json.RawMessage(string(decodedAvro))
 
-		bytes, err := rawJson.MarshalJSON()
+		indentJson, err := json.MarshalIndent(rawJson, "", "\t")
 		if err != nil {
-			log.Error("unable to get Marshal raw json: ", err)
+			log.Error("unable to get indent raw json: ", err)
 		}
 
-		if err = ioutil.WriteFile(outputFilePathFlag+filename+"-specimen.json", bytes, 0600); err != nil {
+		if err = ioutil.WriteFile(outputFilePathFlag+filename+"-specimen.json", indentJson, 0600); err != nil {
 			log.Error("unable to write to file: ", err)
 		}
 

--- a/scripts/extractor.go
+++ b/scripts/extractor.go
@@ -23,6 +23,7 @@ import (
 var (
 	binaryFilePathFlag string
 	avroCodecPathFlag  string
+	outputFilePathFlag string
 	indentJSONFlag     int
 )
 
@@ -30,6 +31,7 @@ func main() {
 	flag.StringVar(&binaryFilePathFlag, "binary-file-path", config.LookupEnvOrString("BinaryFilePath", binaryFilePathFlag), "local path to AVRO encoded binary files that contain block-replicas")
 	flag.StringVar(&avroCodecPathFlag, "codec-path", config.LookupEnvOrString("CodecPath", avroCodecPathFlag), "local path to AVRO .avsc files housing the specimen/result schemas")
 	flag.IntVar(&indentJSONFlag, "indent-json", config.LookupEnvOrInt("IndentJson", indentJSONFlag), "allows for an indented view of the AVRO decoded JSON object")
+	flag.StringVar(&outputFilePathFlag, "output-file-path", config.LookupEnvOrString("OutputFilePath", outputFilePathFlag), "local path to output files for the specimen/result.json")
 
 	flag.Parse()
 	fmt.Println("bsp-extractor command line config: ", utils.GetConfig(flag.CommandLine))
@@ -63,9 +65,16 @@ func main() {
 		if err != nil {
 			log.Error("unable to unmarshal decoded AVRO binary: ", err)
 		}
-		colorJSONMap, _ := colorJSON.Marshal(fileMap)
+		// colorJSONMap, _ := colorJSON.Marshal(fileMap)
 
-		fmt.Println("\nfile: ", filepath.Join(binaryFilePathFlag, filepath.Base(filename)), "bytes: ", size, "\n", string(colorJSONMap))
+		jsonBytes, _ := json.Marshal(string(decodedAvro))
+
+		if err = ioutil.WriteFile(outputFilePathFlag+filename+"-specimen.json", jsonBytes, 0600); err != nil {
+			log.Error("unable to write to file: ", err)
+		}
+
+		fmt.Println("\nfile: ", filepath.Join(outputFilePathFlag, filepath.Base(filename+"-specimen.json")), "bytes: ", size)
+
 	}
 }
 

--- a/scripts/extractor.go
+++ b/scripts/extractor.go
@@ -65,11 +65,15 @@ func main() {
 		if err != nil {
 			log.Error("unable to unmarshal decoded AVRO binary: ", err)
 		}
-		// colorJSONMap, _ := colorJSON.Marshal(fileMap)
 
-		jsonBytes, _ := json.Marshal(string(decodedAvro))
+		rawJson := json.RawMessage(string(decodedAvro))
 
-		if err = ioutil.WriteFile(outputFilePathFlag+filename+"-specimen.json", jsonBytes, 0600); err != nil {
+		bytes, err := rawJson.MarshalJSON()
+		if err != nil {
+			log.Error("unable to get Marshal raw json: ", err)
+		}
+
+		if err = ioutil.WriteFile(outputFilePathFlag+filename+"-specimen.json", bytes, 0600); err != nil {
 			log.Error("unable to write to file: ", err)
 		}
 


### PR DESCRIPTION
* Adds feature to extract .json files from the extractor binary
* Reads an `--out-file-path` flag and synchronously processes all files pointed at with `--binary-file-path`
* Indents all JSON outputs for inspectability and navigation.