### PR TITLE
Post merge fix for historical block agent proof submission

### DIFF
--- a/internal/node/eth_node.go
+++ b/internal/node/eth_node.go
@@ -230,6 +230,8 @@ func (node *ethAgentNode) encodeProveAndUploadReplicaSegment(ctx context.Context
 		return pTxHash, nil
 	case strings.Contains(pTxHash, "out-of-bounds block"):
 		return pTxHash, nil
+	case strings.Contains(pTxHash, "invalid block"):
+		return pTxHash, nil
 	case pTxHash == "":
 		return "", fmt.Errorf("failed to prove & upload block-replica segment event: %v", currentSegment.SegmentName)
 	default:

--- a/internal/proof/proof.go
+++ b/internal/proof/proof.go
@@ -91,6 +91,12 @@ func executeWithRetry(ctx context.Context, proofChainContract *ProofChain, ethCl
 
 			return
 		}
+		if strings.Contains(err.Error(), "Invalid block height") {
+			log.Error("skip creating proof-chain session: ", err)
+			txHash <- "invalid block height"
+
+			return
+		}
 		log.Error("error sending tx to deployed contract: ", err)
 		txHash <- ""
 


### PR DESCRIPTION
Signed-off-by: Pranay Valson <pranay.valson@gmail.com>

* Since the merge we allow submission of all block specimens in a historical sync manner with patched https://github.com/covalenthq/bsp-geth/releases/tag/v1.3.1-bsp

* However we don't historically rewards blocks - hence this patch fixes the erroring out by skipping the historical block proof and moving ahead - allowing the agent to catch up to the most recent valid block its allowed to submit according to the proofchain params set such as 

```
  blockOnTargetChain: BigNumber { value: "14675961" },
  blockOnCurrentChain: BigNumber { value: "2106211" },
  secondsPerBlock: BigNumber { value: "1350" },
  allowedThreshold: BigNumber { value: "200" },
  maxSubmissionsPerBlockHeight: BigNumber { value: "5" },
  nthBlock: BigNumber { value: "3" }
```