### PR TITLE
handles case when tx is already included in tx mempool of node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -o bsp-agent ./cmd/bsp
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -o bsp-extractor ./scripts/extractor.go
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags="-s -w" -o bsp-extractor-2 ./scripts/replica/extractor2.go
 # Runtime/test -  second phase.
-FROM alpine:3.15.0
+FROM alpine:3.15.7
 RUN mkdir /app
 WORKDIR /app
 RUN apk update && apk add --no-cache bash=5.1.16-r0

--- a/internal/node/eth_node.go
+++ b/internal/node/eth_node.go
@@ -216,6 +216,8 @@ func (node *ethAgentNode) encodeProveAndUploadReplicaSegment(ctx context.Context
 		return pTxHash, nil
 	case strings.Contains(pTxHash, "invalid block"):
 		return pTxHash, nil
+	case strings.Contains(pTxHash, "already known"):
+		return pTxHash, nil
 	case pTxHash == "":
 		return "", fmt.Errorf("failed to prove & upload block-replica segment event: %v", currentSegment.SegmentName)
 	default:

--- a/internal/proof/proof.go
+++ b/internal/proof/proof.go
@@ -97,6 +97,13 @@ func executeWithRetry(ctx context.Context, proofChainContract *ProofChain, ethCl
 
 			return
 		}
+		if strings.Contains(err.Error(), "already known") {
+			log.Error("tx already known, skipping: ", err)
+			txHash <- "already known"
+
+			return
+		}
+
 		log.Error("error sending tx to deployed contract: ", err)
 		txHash <- ""
 


### PR DESCRIPTION
node returns "already known" when `WaitMined` timed-out. This change handles this case by logging and skipping, rather than exiting.

This also needs to me merged to main, and a release made available. Subsequently, I want to manage the error checklist a bit better. Possibly by having some kind of enum or map. 