### PR TITLE
Codec version compatibility for `0.33`

### DIFF
--- a/codec/block-ethereum.avsc
+++ b/codec/block-ethereum.avsc
@@ -289,7 +289,7 @@
                                  "type":"array",
                                  "items":"Header"
                               },
-                              "default": []
+                              "default":[]
                            },
                            {
                               "name":"Receipts",
@@ -488,31 +488,35 @@
                            },
                            {
                               "name":"Withdrawals",
-                              "type":{
-                                 "type":"array",
-                                 "items":{
-                                    "name":"Withdrawals_record",
-                                    "type":"record",
-                                    "fields":[
-                                       {
-                                          "name":"index",
-                                          "type":"long"
-                                       },
-                                       {
-                                          "name":"validatorIndex",
-                                          "type":"long"
-                                       },
-                                       {
-                                          "name":"address",
-                                          "type":"string"
-                                       },
-                                       {
-                                          "name":"amount",
-                                          "type":"long"
-                                       }
-                                    ]
+                              "type":[
+                                 "null",
+                                 {
+                                    "type":"array",
+                                    "items":{
+                                       "name":"Withdrawals_record",
+                                       "type":"record",
+                                       "fields":[
+                                          {
+                                             "name":"index",
+                                             "type":"long"
+                                          },
+                                          {
+                                             "name":"validatorIndex",
+                                             "type":"long"
+                                          },
+                                          {
+                                             "name":"address",
+                                             "type":"string"
+                                          },
+                                          {
+                                             "name":"amount",
+                                             "type":"long"
+                                          }
+                                       ]
+                                    }
                                  }
-                              }
+                              ],
+                              "default":"null"
                            }
                         ]
                      }


### PR DESCRIPTION
* Requires that default "null" fields are decoded from an encoded schema that matches it.
* Avrora library limitation of auto filling unavailable fields with default values from write side to read side