### PR TITLE
Remove extra lens wrapping (typo)

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -213,6 +213,8 @@ func Writable(path string) bool {
 }
 
 // UnwrapAvroUnion unwraps avro wrapped maps
+//
+//nolint:dupl
 func UnwrapAvroUnion(data map[string]interface{}) map[string]interface{} {
 	if data == nil {
 		return nil
@@ -264,6 +266,8 @@ func UnwrapAvroUnion(data map[string]interface{}) map[string]interface{} {
 }
 
 // MapToAvroUnion converts the several field in the replica map to an Avro Union type allowing <nil>
+//
+//nolint:dupl
 func MapToAvroUnion(data map[string]interface{}) map[string]interface{} {
 	if data == nil {
 		return nil

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -310,9 +310,6 @@ func MapToAvroUnion(data map[string]interface{}) map[string]interface{} {
 	wrapType(data, rTxLens, "bytes")
 	wrapType(data, sTxLens, "bytes")
 
-	// EIP-7685
-	wrapType(data, requestsHashLens, "string")
-
 	return data
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -35,7 +35,7 @@ const (
 	// BspAgentVersionMinor is Minor version component of the current release
 	BspAgentVersionMinor = 9
 	// BspAgentVersionPatch is Patch version component of the current release
-	BspAgentVersionPatch = 1
+	BspAgentVersionPatch = 2
 )
 
 // BspAgentVersion holds the textual version string.


### PR DESCRIPTION
* Additional avro union type wrapping lead to unrecognized data type, removing this field fixes the issue - 

```
May 07 16:44:49 seed-01.m.test.covalentnetwork.org bspagent[4166159]: time="2025-05-07T16:44:49Z" level=error msg="failed to convert Go map to Avro binary data: cannot encode binary record \"com.covalenthq.brp.avro.ReplicationSegment\" field \"replicaEvent\": value does not match its schema: cannot encode binary array item 1: map[data:map[BlobTxSidecars:map[array:[]] Hash:0x7bd597de4d0b0e16a05a4caaddb46c0e7b23d4ca2fc130882258f68d0a6e019d Header:map[baseFeePerGas:0x604fcd51 blobGasUsed:map[int:393216]
```
...
```
cannot encode binary record "com.covalenthq.brp.avro.replicaEvent" field "data": value does not match its schema: cannot encode binary record "com.covalenthq.brp.avro.data" field "Header": value does not match its schema: cannot encode binary record "com.covalenthq.brp.avro.Header" field "requestsHash": value does not match its schema: cannot encode binary bytes: expected: string; received: map[string]interface {}
``` 