### PR TITLE
Fix Directory Permissions and Type Conversion Issues

### DIFF
--- a/scripts/replica/extractor2.go
+++ b/scripts/replica/extractor2.go
@@ -136,7 +136,13 @@ func filterReplicaSegmentFiles(path string, start int64, end int64, chainID stri
 			}
 			// NOTE: the 2nd condition (fileNameInt <= end) works is segment length is 1 i.e. the block replica segment has 1 replica only (which is the case now)
 			if fileNameInt >= start && fileNameInt <= end {
-				filteredFiles = append(filteredFiles, fileInfo.(fs.FileInfo))
+				info, err := fileInfo.Info()
+				if err != nil {
+					log.Error("unable to get file info: ", err)
+
+					continue
+				}
+				filteredFiles = append(filteredFiles, info)
 			}
 		}
 	}


### PR DESCRIPTION
# Fix Directory Permissions and Type Conversion Issues

## Changes
- Fixed G301 security issue by replacing `os.ModePerm` with more restrictive `0750` permissions in directory creation
- Fixed type conversion panic in `extractor2.go` by properly handling `fs.DirEntry` to `fs.FileInfo` conversion
- Added proper error handling for file operations
- Improved test coverage for utility functions

## Security Improvements
- Directory permissions now follow principle of least privilege (0750)
- File permissions set to 0600 for sensitive data
- Added proper error handling for file operations

## Code Quality
- Added comprehensive test suite for utility functions
- Fixed linting issues including:
  - Error checking for `os.Setenv` and `os.RemoveAll`
  - Package naming in test files
  - Variable naming conventions
  - Blank line formatting
- Improved error handling and logging

## Testing
- Added unit tests for key utility functions
- Improved test coverage for file operations
- Added proper cleanup in tests

## Impact
These changes improve security and reliability of the codebase while maintaining existing functionality. No breaking changes introduced.