### PR TITLE
ci: migrate pinner to Filebase and proof-chain stack to Hardhat

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -42,10 +42,8 @@ jobs:
           {
             echo "PRIVATE_KEY=${{ secrets.PRIVATE_KEY }}"
             echo "RPC_URL=${{ secrets.RPC_URL }}"
-            echo "WEB3_JWT=${{ secrets.WEB3_JWT }}"
-            echo "W3_AGENT_KEY=${{ secrets.W3_AGENT_KEY }}"
+            echo "FILEBASE_RPC_TOKEN=${{ secrets.FILEBASE_RPC_TOKEN }}"
             echo "PROOF_OUT_HEX=${{ secrets.PROOF_OUT_HEX }}"
-            echo "W3_DELEGATION_FILE=${{ secrets.W3_DELEGATION_FILE }}"
           } >> .env
           cat .env
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -42,6 +42,7 @@ jobs:
           {
             echo "PRIVATE_KEY=${{ secrets.PRIVATE_KEY }}"
             echo "RPC_URL=${{ secrets.RPC_URL }}"
+            echo "ERIGON_NODE=${{ secrets.ERIGON_NODE }}"
             echo "FILEBASE_RPC_TOKEN=${{ secrets.FILEBASE_RPC_TOKEN }}"
             echo "PROOF_OUT_HEX=${{ secrets.PROOF_OUT_HEX }}"
           } >> .env

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 
 Decodes, packs, encodes, proves, stores and uploads block-replicas (can be block-results, block-specimens, or any other pre-defined block types), which are primarily "block-specimens" produced by EVM or non-EVM byte code based blockchains.
 
-These block-replicas are produced by go-ethereum nodes / websocket block data sources modified with block-specimen producers(BSP) streamed into a redis channel. The agent first decodes them from their native RLP encoding, repacks them into segments of bigger chunks containing more than one block's worth of data, creates a proof transaction on the proof-chain smart contract (also called cqt-virtnet) with a sha-256 checksum of the data contained in the object, and finally persists them into storage (local and IPFS).
+These block-replicas are produced by go-ethereum nodes / websocket block data sources modified with block-specimen producers(BSP) streamed into a redis channel. The agent first decodes them from their native RLP encoding, repacks them into segments of bigger chunks containing more than one block's worth of data, creates a proof transaction on the proof-chain smart contract with a sha-256 checksum of the data contained in the object, and finally persists them into storage (local and IPFS via the `ewm-das` pinner sidecar).
 
 ## <span id="agent_resources">Resources</span>
 
@@ -153,12 +153,11 @@ For Elrond -
 
 An Ethereum (moonbeam) private key (for a public address that is pre-whitelisted and added as an operator on the covalent network staking contract) allows block-specimen producers (operators) to make proof transactions to the proof-chain contract and is required by the bsp-agent. Other env vars are optional depending on your redis, eth account configuration. Add the following to your `.envrc` at the root dir with final relative path `~/bsp-agent/.envrc`.
 
-An Ethereum (moonbeam) RPC URL specifies the ethereum client connection string used to make transactions to on proof-chain contract, the respective credentials to be able to write to the contract should be provided in the .envrc file as follows. An IPFS Service token should be provided which relates to the JWT token for accessing file uploads on IPFS as a node service - [Pinata](http://pinata.cloud) & account service token for [Web3.Storage](http://web3.storage). These two services are supported for file uploads.
+An Ethereum (moonbeam) RPC URL specifies the ethereum client connection string used to make transactions on the proof-chain contract; the respective credentials to be able to write to the contract should be provided in the `.envrc` file as follows. The agent does **not** hold any storage-service credentials itself — uploads are delegated over HTTP to the [`ewm-das`](https://github.com/covalenthq/ewm-das) pinner sidecar (Filebase-backed; the pinner reads `FILEBASE_RPC_TOKEN` from its own environment, scoped per-bucket from the Filebase console).
 
 ```env
     export MB_RPC_URL=http://127.0.0.1:7545
     export MB_PRIVATE_KEY=****************************************************************
-    export IPFS_SERVICE_TOKEN=*****
     export REDIS_PWD=your-redis-password #optional
     export MB_KEYSTORE_PATH=path/to/keystore/file.json #optional
     export MB_KEYSTORE_PWD=password/to/access/keystore/file.json #optional
@@ -176,7 +175,7 @@ For which you should see something like -
 
 ```bash
     direnv: loading ~/Documents/covalent/bsp-agent/.envrc
-    direnv: export +MB_PRIVATE_KEY +MB_RPC_URL +IPFS_SERVICE_TOKEN
+    direnv: export +MB_PRIVATE_KEY +MB_RPC_URL
 ```
 
 The remaining environment configuration is set up with flags provided to the bsp-agent during runtime.
@@ -205,7 +204,7 @@ go run ./cmd/bspagent/*.go \
   --proof-chain-address="0x8243AF52B91649547DC80814670Dd1683F360E4c" \
   --consumer-timeout=10000000  \
   --log-folder ./logs/  \
-  --ipfs-pinner-server="http://127.0.0.1:3000/""
+  --ipfs-pinner-server="http://127.0.0.1:5080/""
 ```
 
 Or update the Makefile with the correct `--proof-chain-address` and run with the following.
@@ -236,7 +235,7 @@ export REDIS_PWD=your-redis-pwd
 
 `--log-folder` - specifies the location (folder) where the log files have to be placed. In case of error (like permission errors), the logs are not recorded in files.
 
-`--ipfs-pinner-server` - specifies the http server for ipfs-pinner which interacts with ipfs to upload/download files.
+`--ipfs-pinner-server` - specifies the http endpoint for the `ewm-das` pinner sidecar (default listen address `:5080`), which the agent calls to upload/download CAR-packed block replicas and to obtain their CIDs. The pinner handles all Filebase / IPFS credential exchange internally.
 
 `--metrics` - enable metrics collection and reporting
 
@@ -252,8 +251,9 @@ Employ `docker-compose` to get all the necessary services along with the BSP age
 
 1. redis-srv (Open source (BSD licensed), in-memory data structure store)
 1. redis-commander-web (Redis web management tool written in node.js)
-1. ganache-cli (Ethereum blockchain & client)
-1. proof-chain (Validation (proofing) smart-contracts)
+1. ewm-das (IPFS pinner sidecar, Filebase-backed; listens on `:5080`)
+1. hardhat-node (Ethereum mainnet fork, via the `cqt-staking` image; serves RPC on `:8545`)
+1. proof-chain (BSP / BRP validation contracts deployed onto the hardhat fork by `cqt-staking`'s `docker:deploy` script)
 
 ```bash
     cd bsp-agent

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   ewm-das:
-    image: "us-docker.pkg.dev/covalent-project/network/ewm-das:stable"
+    image: "us-docker.pkg.dev/covalent-project/network/ewm-das:latest"
     volumes:
       - ~/.ipfs:/root/.ipfs/
     container_name: ewm-das

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -119,7 +119,7 @@ services:
         exit 0;"
     environment:
       - MB_PRIVATE_KEY=${PRIVATE_KEY}
-      - MB_RPC_URL=${RPC_URL}
+      - MB_RPC_URL=http://hardhat-node:8545/
       - BLOCKCHAIN=${BLOCKCHAIN}
     networks:
       - cxt-net

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -56,47 +56,40 @@ services:
     ports:
       - "8081:8081"
 
-  node:
-    image: trufflesuite/ganache-cli:v6.12.2
-    container_name: ganache-cli
-    restart: always
-    volumes:
-      - ./ganache_data:/ganache_data
-    entrypoint:
-      - node
-      - /app/ganache-core.docker.cli.js
-      - --deterministic
-      - --db=/ganache_data
-      - --mnemonic
-      - "minimum symptom minute gloom tragic situate silver mechanic salad amused elite beef"
-      - --networkId
-      - "5777"
-      - --hostname
-      - "0.0.0.0"
-    depends_on:
-      - redis-commander
-    networks:
-      - cxt-net
-    ports:
-      - "8545:8545"
-
-  cqt-virtnet:
-    image: "ghcr.io/covalenthq/cqt-virtnet:latest"
-    container_name: proof-chain
-    restart: always
+  eth-node:
+    image: "us-docker.pkg.dev/covalent-project/network/cqt-staking:pectra-stable"
+    container_name: hardhat-node
+    restart: on-failure
     expose:
-      - 8008
-    entrypoint: >
+      - "8545:8545"
+    entrypoint: |
       /bin/bash -l -c "
-       truffle migrate --network docker;
-       nc -v agent 8008;
-       sleep 100000;"
-    depends_on:
-      - node
+      echo \"forked-node-address:\" $ERIGON_NODE;
+      ./entrypoint.sh;"
     networks:
       - cxt-net
     environment:
-      npm_config_user: "root"
+      - ERIGON_NODE=${ERIGON_NODE}
+      - NODE_TLS_REJECT_UNAUTHORIZED=0
+    ports:
+      - "8545:8545"
+
+  cqt-staking:
+    image: "us-docker.pkg.dev/covalent-project/network/cqt-staking:pectra-stable"
+    container_name: proof-chain
+    restart: on-failure
+    entrypoint: |
+      /bin/bash -l -c "
+      echo Waiting for hardhat-node to start up...;
+      sleep 20;
+      echo hard-hat node started!;
+      npm run docker:deploy;
+      nc -v agent 8008;
+      sleep 1000000;"
+    depends_on:
+      - eth-node
+    networks:
+      - cxt-net
     ports:
       - "8008:8008"
 
@@ -104,13 +97,13 @@ services:
     image: "us-docker.pkg.dev/covalent-project/network/bsp-agent:latest"
     container_name: bsp-agent
     links:
-      - "cqt-virtnet:proof-chain"
+      - "cqt-staking:proof-chain"
     # build:
     #   context: .
     #   dockerfile: Dockerfile
     restart: on-failure
     depends_on:
-      cqt-virtnet:
+      cqt-staking:
         condition: service_started
       ewm-das:
         condition: service_started
@@ -122,7 +115,7 @@ services:
         sleep 1;
         done;
         echo proof-chain contracts deployed!;
-        ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication#replicate --avro-codec-path=./codec/block-ethereum.avsc --binary-file-path=./bin/block-ethereum/  --block-divisor=3  --log-folder ./logs/ --metrics --metrics.port 6063 --metrics.addr 0.0.0.0 --proof-chain-address=0xEa2ff902dbeEECcc828757B881b343F9316752e5 --consumer-timeout=15 --ipfs-pinner-server="http://ewm-das:5080/";
+        ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication#replicate --avro-codec-path=./codec/block-ethereum.avsc --binary-file-path=./bin/block-ethereum/  --block-divisor=3  --log-folder ./logs/ --metrics --metrics.port 6063 --metrics.addr 0.0.0.0 --proof-chain-address=0xce44d283b806C62698285D83c2Ca3F1e42Eb7112 --consumer-timeout=15 --ipfs-pinner-server="http://ewm-das:5080/";
         exit 0;"
     environment:
       - MB_PRIVATE_KEY=${PRIVATE_KEY}

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -11,20 +11,18 @@ services:
       /bin/bash -l -c "
         touch proof_out_hex.txt;
         chmod +x proof_out_hex.txt;
-        echo "$PROOF_OUT_HEX" > proof_out_hex.txt;
+        echo \"$PROOF_OUT_HEX\" > proof_out_hex.txt;
         xxd -r -p proof_out_hex.txt > proof_from_hex.out;
         chmod +x proof_from_hex.out;
         mv ./proof_from_hex.out /root/.ipfs/proof_from_hex.out;
-        ./usr/local/bin/pinner --addr :5080 --w3-agent-key $W3_AGENT_KEY --w3-delegation-proof-path $W3_DELEGATION_FILE;"
+        ./usr/local/bin/pinner --log-level debug --addr :5080;"
     environment:
-      - W3_AGENT_KEY=${W3_AGENT_KEY}
-      - W3_DELEGATION_FILE=${W3_DELEGATION_FILE}
+      - FILEBASE_RPC_TOKEN=${FILEBASE_RPC_TOKEN}
       - PROOF_OUT_HEX=${PROOF_OUT_HEX}
     networks:
       - cxt-net
     ports:
       - "4001:4001"
-      - "3001:3001"
       - "5080:5080"
 
   redis:

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -88,8 +88,6 @@ services:
       - 8008
     entrypoint: >
       /bin/bash -l -c "
-       mkdir -p /root/.config/truffle/compilers;
-       wget -q -O /root/.config/truffle/compilers/soljson-v0.8.13+commit.abaa5c0e.js https://binaries.soliditylang.org/wasm/soljson-v0.8.13+commit.abaa5c0e.js;
        truffle migrate --network docker;
        nc -v agent 8008;
        sleep 100000;"

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -88,6 +88,8 @@ services:
       - 8008
     entrypoint: >
       /bin/bash -l -c "
+       mkdir -p /root/.config/truffle/compilers;
+       wget -q -O /root/.config/truffle/compilers/soljson-v0.8.13+commit.abaa5c0e.js https://binaries.soliditylang.org/wasm/soljson-v0.8.13+commit.abaa5c0e.js;
        truffle migrate --network docker;
        nc -v agent 8008;
        sleep 100000;"

--- a/docker-compose-hardhat.yml
+++ b/docker-compose-hardhat.yml
@@ -1,30 +1,29 @@
 version: '3'
 
 services:
-  ipfs-pinner:
-    image: "us-docker.pkg.dev/covalent-project/network/ipfs-pinner:stable"
+  ewm-das:
+    image: "us-docker.pkg.dev/covalent-project/network/ewm-das:stable"
     volumes:
       - ~/.ipfs:/root/.ipfs/
-    container_name: ipfs-pinner
+    container_name: ewm-das
     restart: on-failure
     entrypoint: |
       /bin/bash -l -c "
         touch proof_out_hex.txt;
         chmod +x proof_out_hex.txt;
-        echo "$PROOF_OUT_HEX" > proof_out_hex.txt;
+        echo \"$PROOF_OUT_HEX\" > proof_out_hex.txt;
         xxd -r -p proof_out_hex.txt > proof_from_hex.out;
         chmod +x proof_from_hex.out;
         mv ./proof_from_hex.out /root/.ipfs/proof_from_hex.out;
-        ./ipfs-server -port 3001 -w3-agent-key $W3_AGENT_KEY -w3-delegation-file $W3_DELEGATION_FILE;"
+        ./usr/local/bin/pinner --log-level debug --addr :5080;"
     environment:
-      - W3_AGENT_KEY=${W3_AGENT_KEY}
-      - W3_DELEGATION_FILE=${W3_DELEGATION_FILE}
+      - FILEBASE_RPC_TOKEN=${FILEBASE_RPC_TOKEN}
       - PROOF_OUT_HEX=${PROOF_OUT_HEX}
     networks:
       - cqt-net
     ports:
       - "4001:4001"
-      - "3001:3001"
+      - "5080:5080"
 
   redis:
     image: redis:alpine
@@ -116,7 +115,7 @@ services:
         sleep 1;
         done;
         echo proof-chain contracts deployed!;
-        ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication#replicate --avro-codec-path=./codec/block-ethereum.avsc --binary-file-path=./bin/block-ethereum/  --block-divisor=3  --log-folder ./logs/ --metrics --metrics.port 6063 --metrics.addr 0.0.0.0 --proof-chain-address=0xce44d283b806C62698285D83c2Ca3F1e42Eb7112 --consumer-timeout=100000 --ipfs-pinner-server="http://ipfs-pinner:3001/";
+        ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication#replicate --avro-codec-path=./codec/block-ethereum.avsc --binary-file-path=./bin/block-ethereum/  --block-divisor=3  --log-folder ./logs/ --metrics --metrics.port 6063 --metrics.addr 0.0.0.0 --proof-chain-address=0xce44d283b806C62698285D83c2Ca3F1e42Eb7112 --consumer-timeout=100000 --ipfs-pinner-server="http://ewm-das:5080/";
         exit 0;"
     environment:
       - MB_PRIVATE_KEY=${PRIVATE_KEY}

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -11,20 +11,19 @@ services:
       /bin/bash -l -c "
         touch proof_out_hex.txt;
         chmod +x proof_out_hex.txt;
-        echo "$PROOF_OUT_HEX" > proof_out_hex.txt;
+        echo \"$PROOF_OUT_HEX\" > proof_out_hex.txt;
         xxd -r -p proof_out_hex.txt > proof_from_hex.out;
         chmod +x proof_from_hex.out;
         mv ./proof_from_hex.out /root/.ipfs/proof_from_hex.out;
-        ./usr/local/bin/pinner --addr :5080 --w3-agent-key $W3_AGENT_KEY --w3-delegation-proof-path $W3_DELEGATION_FILE;"
+        ./usr/local/bin/pinner --log-level debug --addr :5080;"
     environment:
-      - W3_AGENT_KEY=${W3_AGENT_KEY}
-      - W3_DELEGATION_FILE=${W3_DELEGATION_FILE}
+      - FILEBASE_RPC_TOKEN=${FILEBASE_RPC_TOKEN}
       - PROOF_OUT_HEX=${PROOF_OUT_HEX}
     networks:
       - cqt-net
     ports:
       - "4001:4001"
-      - "3001:3001"
+      - "5080:5080"
 
   redis:
     image: redis:alpine
@@ -123,7 +122,7 @@ services:
         sleep 1;
         done;
         echo proof-chain contracts deployed!;
-        ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication-2#replicate --avro-codec-path=./codec/block-ethereum.avsc --binary-file-path=./bin/block-ethereum/  --block-divisor=3  --log-folder ./logs/ --metrics --metrics.port 6063 --metrics.addr 0.0.0.0 --proof-chain-address=0xEa2ff902dbeEECcc828757B881b343F9316752e5 --consumer-timeout=100000 --ipfs-pinner-server="http://ewm-das:3001/";
+        ./bsp-agent --redis-url=redis://username:@redis:6379/0?topic=replication-2#replicate --avro-codec-path=./codec/block-ethereum.avsc --binary-file-path=./bin/block-ethereum/  --block-divisor=3  --log-folder ./logs/ --metrics --metrics.port 6063 --metrics.addr 0.0.0.0 --proof-chain-address=0xEa2ff902dbeEECcc828757B881b343F9316752e5 --consumer-timeout=100000 --ipfs-pinner-server="http://ewm-das:5080/";
         exit 0;"
     environment:
       - MB_PRIVATE_KEY=${PRIVATE_KEY}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -33,9 +33,9 @@ const (
 	// BspAgentVersionMajor is Major version component of the current release
 	BspAgentVersionMajor = 1
 	// BspAgentVersionMinor is Minor version component of the current release
-	BspAgentVersionMinor = 9
+	BspAgentVersionMinor = 11
 	// BspAgentVersionPatch is Patch version component of the current release
-	BspAgentVersionPatch = 2
+	BspAgentVersionPatch = 0
 )
 
 // BspAgentVersion holds the textual version string.


### PR DESCRIPTION
## Summary

This PR does two things, both gated on upstream changes that the bsp-agent CI was no longer compatible with:

1. **Pinner migration** — bring bsp-agent in line with [ewm-das#72](https://github.com/covalenthq/ewm-das/pull/72) (Filebase replacement for the retired w3 CLI). The pinner is now `FILEBASE_RPC_TOKEN`-only, listens on `:5080`, and drops `--w3-agent-key`/`--w3-delegation-proof-path`.
2. **Proof-chain stack swap** — replace `trufflesuite/ganache-cli` + `ghcr.io/covalenthq/cqt-virtnet:latest` (Truffle 5.4.21, last built Jan 2023, broken since `solc-bin.ethereum.org` started 301-redirecting) with `us-docker.pkg.dev/covalent-project/network/cqt-staking:pectra-stable` (hardhat fork-from-mainnet). This mirrors the proof-chain stack [covalenthq/refiner](https://github.com/covalenthq/refiner) already uses in CI today.

The two changes ship together because the bsp-agent CI workflow runs both as one stack — neither half is independently testable.

## Confirmation — CI is green end-to-end

The agent runs all the way through: it consumes a replica from Redis, encodes it, pins via the new Filebase-backed pinner, submits the proof tx through the hardhat fork, and writes the binary file out locally.

```
ewm-das       | INFO  generated dag has root cid: bafybei…
bsp-agent     | Proof-chain tx hash: 0xbab629ab…b60199 for block-replica segment: 1-19727343-replica
bsp-agent     | File written successfully to: ./bin/block-ethereum/1-19727343-replica-0xbab629ab…
```

## File-by-file

### Pinner migration (Filebase)
- **`docker-compose-ci.yml`**, **`docker-compose-local.yml`**, **`docker-compose-hardhat.yml`** — swap `W3_*` env + `--w3-*` pinner flags for `FILEBASE_RPC_TOKEN`; drop port `3001`; fix `$PROOF_OUT_HEX` shell-escaping. `docker-compose-hardhat.yml` also moves off the legacy `ipfs-pinner` image to the unified `ewm-das` one.
- **`.github/workflows/docker-image.yml`** — drop `WEB3_JWT`, `W3_AGENT_KEY`, `W3_DELEGATION_FILE` from the generated `.env`; add `FILEBASE_RPC_TOKEN`.
- **`.envrc`** (gitignored, local-only) — drop `W3_*`/`WEB3_JWT` exports; add `FILEBASE_RPC_TOKEN` placeholder.

### Proof-chain stack swap (Truffle → Hardhat)
- **`docker-compose-ci.yml`** —
  - Remove the `node` (`ganache-cli`) service and the `cqt-virtnet` service entirely.
  - Add `eth-node` (cqt-staking image as `hardhat-node`, forks from `$ERIGON_NODE`) and `cqt-staking` (proof-chain deployer, runs `npm run docker:deploy`).
  - Repoint the `agent`'s `links`/`depends_on` to `cqt-staking`; flip `--proof-chain-address` from the ganache-deterministic `0xEa2ff902…` to the hardhat-deployed `0xce44d283…` (same address refiner uses).
  - Hardcode `MB_RPC_URL=http://hardhat-node:8545/`. The `RPC_URL` secret still pointed at `ganache-cli`, which doesn't exist on the network anymore; sourcing the URL from a stale secret was the cause of the post-swap "dial tcp: lookup ganache-cli" failure mid-PR.
- **`.github/workflows/docker-image.yml`** — pass `ERIGON_NODE` into `.env` so the hardhat fork has an upstream RPC.

## Required CI setup (out of band)

These need to exist as repo secrets on `covalenthq/bsp-agent` before CI passes:
- **`FILEBASE_RPC_TOKEN`** — Filebase IPFS RPC API token, scoped per-bucket (Filebase console → bucket settings).
- **`ERIGON_NODE`** — mainnet RPC URL for the hardhat fork. Use the same value refiner has.
- **`PRIVATE_KEY`** — set for (BSP operator from `cqt-staking`'s `deployContractsAndAddOperators.js`, derives to `0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65`, which is the whitelisted Block Specimen Producer on the hardhat-deployed BSP proof-chain). Well-known test mnemonic, no real funds.

Retired (can be deleted once this merges): `WEB3_JWT`, `W3_AGENT_KEY`, `W3_DELEGATION_FILE`.

## Now unused

- `ghcr.io/covalenthq/cqt-virtnet:latest` image — no remaining bsp-agent consumer.
- `./ganache_data/` directory still in the repo tree but referenced by no compose file. Worth a follow-up `git rm -r`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)